### PR TITLE
wip: idempotency for certain async methods

### DIFF
--- a/src/classes/Hoshimi.ts
+++ b/src/classes/Hoshimi.ts
@@ -241,7 +241,7 @@ export class Hoshimi extends EventEmitter<HoshimiEvents> {
                     return;
                 }
 
-                if (await player.data.get("internal_playerDestroy")) {
+                if (player.destroyed) {
                     this.emit(
                         EventNames.Debug,
                         DebugLevels.Player,
@@ -285,7 +285,7 @@ export class Hoshimi extends EventEmitter<HoshimiEvents> {
                         return;
                     }
 
-                    if (await player.data.get("internal_playerDestroy")) {
+                    if (player.destroyed) {
                         this.emit(
                             EventNames.Debug,
                             DebugLevels.Player,

--- a/src/classes/player/Player.ts
+++ b/src/classes/player/Player.ts
@@ -36,6 +36,10 @@ import type { NullableVoiceChannelUpdate } from "./Voice";
  * @class Player
  */
 export class Player {
+    /**
+     * Promise of the destroying player.
+     * @type {PromiseWithResolvers<void>["promise"] | null}
+     */
     private destroyPromise: PromiseWithResolvers<void>["promise"] | null = null;
 
     /**
@@ -118,6 +122,14 @@ export class Player {
      * @default false
      */
     public connected: boolean = false;
+
+    /**
+     * Check if the player is destroyed.
+     * @type {boolean}
+     */
+    public get destroyed(): boolean {
+        return this.destroyPromise != null || this.manager.players.get(this.guildId) !== this;
+    }
 
     /**
      * Volume of the player.
@@ -549,7 +561,14 @@ export class Player {
      * ```
      */
     public async destroy(options: DestroyOptions = {}): Promise<void> {
-        if (this.destroyPromise) return this.destroyPromise;
+        if (this.destroyPromise) {
+            this.manager.emit(
+                EventNames.Debug,
+                DebugLevels.Player,
+                `[Player] -> [Destroy] Player for guild: ${this.guildId} is already being destroyed.`,
+            );
+            return this.destroyPromise;
+        }
 
         const { reason = DestroyReasons.Stop, disconnect = true } = options;
         const resolver = createResolver<void>();

--- a/src/classes/player/Player.ts
+++ b/src/classes/player/Player.ts
@@ -22,9 +22,10 @@ import {
     type TrackStructure,
 } from "../../types/Structures";
 import { LoopValues } from "../../util/constants";
-import { validatePlayerOptions } from "../../util/functions/utils";
+import { createResolver, validatePlayerOptions } from "../../util/functions/utils";
 import { PlayerError } from "../Errors";
 import type { Hoshimi } from "../Hoshimi";
+import type { PromiseWithResolvers } from "../../types/Utility";
 import type { PlayerStorageAdapter } from "../storage/adapters/PlayerAdapter";
 import type { TrackResolvableStructure } from "../Track";
 import type { FilterManager } from "./filters/Manager";
@@ -35,6 +36,8 @@ import type { NullableVoiceChannelUpdate } from "./Voice";
  * @class Player
  */
 export class Player {
+    private destroyPromise: PromiseWithResolvers<void>["promise"] | null = null;
+
     /**
      * The data for the player.
      * @type {PlayerStorageAdapter}
@@ -546,17 +549,12 @@ export class Player {
      * ```
      */
     public async destroy(options: DestroyOptions = {}): Promise<void> {
-        const { reason = DestroyReasons.Stop, disconnect = true } = options;
+        if (this.destroyPromise) return this.destroyPromise;
 
-        const claimed: boolean = await this.data.setIfAbsent("internal_playerDestroy", true);
-        if (!claimed) {
-            this.manager.emit(
-                EventNames.Debug,
-                DebugLevels.Player,
-                `[Player] -> [Destroy] Player for guild: ${this.guildId} is already being destroyed.`,
-            );
-            return;
-        }
+        const { reason = DestroyReasons.Stop, disconnect = true } = options;
+        const resolver = createResolver<void>();
+
+        this.destroyPromise = resolver.promise;
 
         try {
             if (disconnect) await this.disconnect();
@@ -577,6 +575,8 @@ export class Player {
                 DebugLevels.Player,
                 `[Player] -> [Destroy] Destroyed player for guild: ${this.guildId} | Reason: ${reason}`,
             );
+            resolver.resolve();
+            this.destroyPromise = null;
         }
     }
 

--- a/src/types/Utility.ts
+++ b/src/types/Utility.ts
@@ -1,0 +1,7 @@
+export type PromiseResolvers<T> = Parameters<ConstructorParameters<typeof Promise<T>>[0]>;
+
+export type PromiseWithResolvers<T> = {
+    promise: Promise<T>;
+    reject: PromiseResolvers<T>[1];
+    resolve: PromiseResolvers<T>[0];
+};

--- a/src/util/events/player.ts
+++ b/src/util/events/player.ts
@@ -152,7 +152,7 @@ export async function trackEnd(this: PlayerStructure, payload: TrackEndEvent): P
 
     const reasons: TrackEndReason[] = [TrackEndReason.LoadFailed, TrackEndReason.Cleanup];
     if (reasons.includes(payload.reason)) {
-        if (await this.data.get("internal_playerDestroy")) {
+        if (this.destroyed) {
             this.manager.emit(
                 EventNames.Debug,
                 DebugLevels.Player,

--- a/src/util/functions/utils.ts
+++ b/src/util/functions/utils.ts
@@ -10,6 +10,7 @@ import type { AnyLavalinkTrack, PlayerOptions } from "../../types/Player";
 import type { TrackJSON } from "../../types/Queue";
 import type { UpdatePlayerInfo } from "../../types/Rest";
 import type { NodeStructure, PlayerStructure, TrackStructure } from "../../types/Structures";
+import type { PromiseWithResolvers } from "../../types/Utility";
 import { UrlRegex } from "../constants";
 
 /**
@@ -480,4 +481,16 @@ function isNode(options: NodeOptions): boolean {
         (typeof options.heartbeat?.interval === "number" || typeof options.heartbeat?.interval === "undefined") &&
         (typeof options.heartbeat?.statsTimeout === "number" || typeof options.heartbeat?.statsTimeout === "undefined")
     );
+}
+
+/**
+ * Create a promise with resolvers.
+ */
+export function createResolver<T>() {
+    const resolver = {} as PromiseWithResolvers<T>;
+    resolver.promise = new Promise<T>((resolve, reject) => {
+        resolver.reject = reject;
+        resolver.resolve = resolve;
+    });
+    return resolver;
 }


### PR DESCRIPTION
This PR tries to make certain async methods like `Player#destroy()` safe for multiple callers to await simultaneously while the underlying logic runs only once.

It uses a helper function serving as a replacement for [promise-with-resolvers](https://github.com/tc39/proposal-promise-with-resolvers) since the current target does not include that feature.