### PR TITLE
chore: release packages

### DIFF
--- a/.changeset/audit-findings.md
+++ b/.changeset/audit-findings.md
@@ -1,0 +1,19 @@
+---
+"hoshimi": patch
+---
+
+Fixes from an audit of the whole client:
+
+- **Voice**: a `VOICE_STATE_UPDATE` from any other guild member overwrote the player's session id with theirs, because the `user_id` check ran after the first `voice.patch()`. The next `VOICE_SERVER_UPDATE` then built its payload from a foreign session, which Lavalink closes with a 4006.
+- **Player**: `move()` threw a `TypeError` whenever `queue.current` was `null` with a non-empty queue — the null filter was `t != null || typeof t !== "undefined"`, which is `true` for `null`. The source filter had the same shape and let `undefined` through into `sourceManagers.includes()`, reporting a missing source manager that did not exist.
+- **Storage**: `QueueMemoryStorage.get()` read the raw key while `set`/`has`/`delete` went through `buildKey`, so it never found anything. `QueueUtils.sync()` always threw `StorageError`, which broke `resumeByLibrary` (swallowed as a `nodeError`).
+- **Queue**: `save()` measured `tracks.length` to trim the history, dropping entries well within `maxHistory`. `move(track, 0)` sent the track to the end instead of the front. `toJSON()` only threw on invalid tracks when *every* track was invalid, and mutated `this.history` from inside a serializer. `splice()` duplicated the tracks it inserted into an empty queue, and `move()` cost three storage writes and three `queueUpdate` events.
+- **Queue writes on track end** were not awaited under `LoopMode.Track`/`Queue`, racing the following `save()`.
+- **Search**: a plain `http://host/file.mp3` reached Lavalink with its scheme stripped, because the registered `http` source was parsed off the front of it.
+- **Autoplay**: the random index was computed over the unfiltered results and then indexed into the filtered list, so it frequently resolved to `undefined` and queued nothing.
+- **Filters**: `commit()` read the advertised list as `info?.filters ?? []` and dropped every top-level filter missing from it, so on a node that had not answered `/v4/info` yet, `reset()`, `clear()`, `setEQBand()` and a bare `apply()` silently sent an empty payload.
+- **Rest**: every request logged the `Authorization` header verbatim, putting the node password in the consumer's debug sink.
+- **Player storage**: `values()` returned the `internal_*` bookkeeping keys that `keys()`, `entries()` and `all()` filter out.
+- **Player**: `skip({ throwError: false })` on an empty queue threw a `ResolveError` — exactly the throw the caller opted out of.
+- **Manager**: `init()` accepted the placeholder default client id `"0"`, connecting every node with `User-Id: 0` instead of failing with the intended `ManagerError`.
+- **Validation**: numeric options only checked `typeof === "number"`, accepting `NaN`, `Infinity`, negatives and fractions. Those fail silently — `retryAmount: NaN` never reaches `0`, so a node reconnects forever. Ports are now range-checked too.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,8 +4,8 @@
     "commit": false,
     "fixed": [],
     "linked": [],
-    "access": "restricted",
-    "baseBranch": "main",
+    "access": "public",
+    "baseBranch": "lib",
     "updateInternalDependencies": "patch",
     "ignore": []
 }

--- a/.changeset/filters-presence-api.md
+++ b/.changeset/filters-presence-api.md
@@ -1,0 +1,34 @@
+---
+"hoshimi": minor
+---
+
+Filters are now active by presence, and any filter can be set — registered or not.
+
+`FilterManager.data` used to start as a clone of `DefaultPlayerFilters` (a neutral `timescale: {1,1,1}`, an all-zero `karaoke`, a full `pluginFilters` tree...) and `commit()` stripped whatever still matched those shapes, deciding "active" through per-filter `isDefault` predicates. Never-set and set-to-something-neutral were indistinguishable on the wire. A key is now present only while its filter is active:
+
+- `data` starts empty, so a fresh commit sends `{}`.
+- `isEnabled(name)` is presence — `setVolume(1)` counts as active.
+- `clear(name)` and `clearEQBands()` delete the key instead of neutralising it; `reset()` empties the payload.
+
+New `FilterManager.set(name, payload, options?)`, the universal setter `apply(name, payload)` was trying to be. Filters the registry does not know need no registration at all — `SetFilterOptions` picks the envelope, and an explicit option overrides whatever the registry resolved:
+
+```ts
+await fm.set("myFilter", { gain: 2 });                              // pluginFilters.myFilter
+await fm.set("boost", { gain: 2 }, { plugin: "my-plugin" });        // pluginFilters["my-plugin"].boost
+await fm.set("forkEcho", { decay: 0.5 }, { top: true });            // filters.forkEcho
+await fm.set(FilterType.Timescale, payload, { validate: false });   // skip the node check
+```
+
+`clear`, `isEnabled` and `has` take the same routing options. `apply()` keeps its no-arg commit meaning; the two-argument overload is deprecated in favour of `set`.
+
+**Breaking changes**
+
+- `DefaultPlayerFilters` is gone: with presence semantics there is no neutral payload. `DefaultFilterPreset` and `AudioOutputData` stay.
+- Reading `data.timescale.speed` and friends yields `undefined` until the filter is set.
+- `FilterRegistration.isDefault` and `defaultPayload` removed (the latter was never read by anything), and the interface is no longer generic.
+- `FilterRegistry.isDefault`, `isDefaultFlatPlugin`, `isWireKey`, `getAll`, `getByScope` and `getByPlugin` removed. `isPluginName` and `isKnown` replace what the library actually needed.
+- `FilterScope.Vendor`, `FilterRegistration.vendors`, `RegistryVendorName` and `CustomizableVendors` removed. Which server a player talks to is the node's concern: fork filters go top-level through `set(name, payload, { top: true })`, or by registering them with scope `Core`. Nothing is lost for Nodelink, whose filters were top-level already.
+- `FilterType.AudioOutput` and `FilterType.Custom` removed: neither named a Lavalink filter nor was registered.
+- `EnabledPlayerFilters`, `EnabledLavalinkFilters` and `EnabledDSPXPluginFilters` removed, dead since the toggle object was dropped.
+- `defineFilter` is now a deprecated pass-through.
+- `heartbeat.statsTimeout` removed from node and manager options. It was plumbed through types, defaults and validation, and documented as a stats watchdog, but nothing ever armed a timer — only the ping/pong heartbeat was implemented.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: Build, Lint, Format & Publish
+name: Test, Lint, Format & Publish
 on:
   push:
   pull_request:
@@ -9,7 +9,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The lowest runtime the README supports, plus the version the other jobs use.
+        node-version: ['22.x', '24.x']
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Redundant today (`prepare` -> `pnpm build` -> `pnpm typecheck`), kept as an explicit gate so the
+      # check does not silently disappear if that lifecycle script ever changes.
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Run tests
+        run: pnpm test
+
   linter:
+    # Nothing gets pushed back or published off a red test run.
+    needs: test
     runs-on: ubuntu-latest
     permissions:
         contents: write
@@ -47,7 +78,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HUSKY: 0
-        
+
 
       - name: Publish in pkg.pr.new
         run: pnpx pkg-pr-new publish

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # This publishes to npm on every push to lib, so it does not go out on a red suite.
+      - name: Run tests
+        run: pnpm test
+
       - name: Verify npm token
         run: npm whoami
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run tests
+        run: pnpm test
+
       - name: Create Release Pull Request
         uses: changesets/action@v1
         env:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - 📣 **Events**: Granular events with debug levels.
 - 🧩 **Extensible**: Override structures with your own ones.
 - 🧪 **Safety & DX**: Strict validation, descriptive errors, TypeScript-first API build, and formatting/linting.
-- 📜 **Filters**: Built-in filters, easy management and easy to use!  
+- 📜 **Filters**: Built-in filters, plugin filters, and anything your fork exposes — no registration needed.  
 
 ## ⚙️ Requirements
 - **Runtime** - atleast one of:
@@ -101,6 +101,84 @@ client.events.values.RAW = {
     await client.start();
 })();
 ```
+
+## 📜 Filters
+
+A filter is active while its key is in the payload. There is no "off" payload: `clear` removes the key,
+and `isEnabled` is presence.
+
+```typescript
+import { FilterType } from "hoshimi";
+
+const player = hoshimi.getPlayer("guildId");
+
+await player.filterManager.setNightcore();
+await player.filterManager.set(FilterType.Echo, { delay: 200, decay: 0.5 });
+
+player.filterManager.isEnabled(FilterType.Echo); // true
+player.filterManager.getEnabled();               // ["timescale", "echo"]
+player.filterManager.get(FilterType.Timescale);  // TimescaleSettings | undefined
+
+await player.filterManager.clear(FilterType.Echo);
+await player.filterManager.reset();              // drops every filter
+```
+
+`set` and `get` are typed per filter, so the payload of a built-in is checked for you — `set(FilterType.Volume, { nope: true })` does not compile.
+
+Filters Hoshimi has never heard of work too — a fork's own filters, a plugin you wrote, anything. The
+envelope comes from the options:
+
+```typescript
+// pluginFilters.myFilter — the extension point the Lavalink v4 spec defines
+await player.filterManager.set("myFilter", { gain: 2 });
+
+// pluginFilters["my-plugin"].boost — nested, per the spec's plugin shape
+await player.filterManager.set("boost", { gain: 2 }, { plugin: "my-plugin" });
+
+// filters.forkEcho — top level, next to the built-ins, where forks expose theirs
+await player.filterManager.set("forkEcho", { decay: 0.5 }, { top: true });
+
+// Clear it from the same envelope it was written to
+await player.filterManager.clear("boost", { plugin: "my-plugin" });
+```
+
+Hoshimi does not check which server it is talking to, so whether a fork-specific filter is safe to send
+is up to you: point the player at a node that understands it.
+
+Registering a filter is **optional**. Do it to get routing by name — no options at the call site — plus a
+check against what the node advertises in `/v4/info`:
+
+```typescript
+import { FilterRegistry, FilterScope, PluginCapabilities } from "hoshimi";
+
+FilterRegistry.register({
+    name: "boost",
+    scope: FilterScope.Plugin,      // Plugin -> pluginFilters · Core -> top level
+    pluginName: "my-plugin",        // omit to write it flat under pluginFilters
+    capability: PluginCapabilities.Filters,
+});
+
+await player.filterManager.set("boost", { gain: 2 }); // routed and validated
+```
+
+`set(name, payload, { validate: false })` skips that check when a node fails to advertise a filter it
+actually supports.
+
+To type a filter of your own, declare its payload — the key is the filter name, the value is what it
+takes. That gives you autocompletion for the name and a checked payload in `set` and `get`:
+
+```typescript
+declare module "hoshimi" {
+    interface CustomizableFilters {
+        forkEcho: { decay: number; delay: number };
+    }
+}
+
+await player.filterManager.set("forkEcho", { decay: 0.5, delay: 200 }, { top: true });
+player.filterManager.get("forkEcho", { top: true }); // { decay: number; delay: number } | undefined
+```
+
+A filter nobody declared takes `unknown`, so ad-hoc payloads keep working without any of this.
 
 ## 💖 Used By
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
     "assist": {
         "actions": {
             "source": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.cts",
-    "packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25",
+    "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72",
     "exports": {
         ".": {
             "types": "./dist/index.d.cts",
@@ -48,13 +48,13 @@
     "author": "Ganyu Studios",
     "license": "MIT",
     "devDependencies": {
-        "@biomejs/biome": "^2.5.4",
-        "@changesets/cli": "^2.31.0",
+        "@biomejs/biome": "^2.5.5",
+        "@changesets/cli": "^2.31.1",
         "@types/node": "^26.1.1",
         "@types/ws": "^8.18.1",
         "husky": "^9.1.7",
-        "lint-staged": "^17.0.8",
-        "tsdown": "^0.22.8",
+        "lint-staged": "^17.2.0",
+        "tsdown": "^0.22.14",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.cts",
-    "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a",
+    "packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25",
     "exports": {
         ".": {
             "types": "./dist/index.d.cts",
@@ -48,18 +48,18 @@
     "author": "Ganyu Studios",
     "license": "MIT",
     "devDependencies": {
-        "@biomejs/biome": "^2.5.3",
+        "@biomejs/biome": "^2.5.4",
         "@changesets/cli": "^2.31.0",
         "@types/node": "^26.1.1",
         "@types/ws": "^8.18.1",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
-        "tsdown": "^0.22.7",
+        "tsdown": "^0.22.8",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10"
     },
     "dependencies": {
-        "ws": "^8.21.0"
+        "ws": "^8.21.1"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,12 +9,12 @@ importers:
   .:
     dependencies:
       ws:
-        specifier: ^8.21.0
-        version: 8.21.0
+        specifier: ^8.21.1
+        version: 8.21.1
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.3
-        version: 2.5.3
+        specifier: ^2.5.4
+        version: 2.5.4
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@26.1.1)
@@ -31,8 +31,8 @@ importers:
         specifier: ^17.0.8
         version: 17.0.8
       tsdown:
-        specifier: ^0.22.7
-        version: 0.22.7(tsx@4.23.1)(typescript@7.0.2)
+        specifier: ^0.22.8
+        version: 0.22.8(tsx@4.23.1)(typescript@7.0.2)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -49,59 +49,59 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.5.3':
-    resolution: {integrity: sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==}
+  '@biomejs/biome@2.5.4':
+    resolution: {integrity: sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.3':
-    resolution: {integrity: sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==}
+  '@biomejs/cli-darwin-arm64@2.5.4':
+    resolution: {integrity: sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.3':
-    resolution: {integrity: sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==}
+  '@biomejs/cli-darwin-x64@2.5.4':
+    resolution: {integrity: sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.3':
-    resolution: {integrity: sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==}
+  '@biomejs/cli-linux-arm64-musl@2.5.4':
+    resolution: {integrity: sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.3':
-    resolution: {integrity: sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==}
+  '@biomejs/cli-linux-arm64@2.5.4':
+    resolution: {integrity: sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.3':
-    resolution: {integrity: sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==}
+  '@biomejs/cli-linux-x64-musl@2.5.4':
+    resolution: {integrity: sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.3':
-    resolution: {integrity: sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==}
+  '@biomejs/cli-linux-x64@2.5.4':
+    resolution: {integrity: sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.3':
-    resolution: {integrity: sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==}
+  '@biomejs/cli-win32-arm64@2.5.4':
+    resolution: {integrity: sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.3':
-    resolution: {integrity: sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==}
+  '@biomejs/cli-win32-x64@2.5.4':
+    resolution: {integrity: sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -639,125 +639,125 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
-  '@yuku-codegen/binding-darwin-arm64@0.6.1':
-    resolution: {integrity: sha512-LDJtpOKtcv9f3V0eDUwFmmy47t2VC+DAuN+gq80R1IA+fa0d408i6sHsVtt6n+g5rf8f86ySoPSAe94lHt6Ixw==}
+  '@yuku-codegen/binding-darwin-arm64@0.6.3':
+    resolution: {integrity: sha512-pbDcFygFmbvo0jGFq5U0m5Sa9U8aVttVJWbBHZDZ68w/X48HdDWS1V4XvBacs8XkmWbTr/ef5fMGG7HsngqTmg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@yuku-codegen/binding-darwin-x64@0.6.1':
-    resolution: {integrity: sha512-fBwpBOh33W7N87F94SVNExwm2KUV3ROhk51okr3Oy2ost1/JJuBWINVjcgwd2WPKZEFzUXgCzj/03UR/G+WIrQ==}
+  '@yuku-codegen/binding-darwin-x64@0.6.3':
+    resolution: {integrity: sha512-qZMrnA4i8OfqL3NMGoOvLdh1vby8cCGsmNo+tJQIIezXO557m3fdQLenz/57GqtBnnGWzWqd/aDp+faNxWlLwQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-codegen/binding-freebsd-x64@0.6.1':
-    resolution: {integrity: sha512-UpMkskQV3a5oPnJV+GFFupIqnLwSBD4ZsZAVUZuNVkrqct433FHKqTwuG+P5JhHZbmhf+++3Ie/V2sgduyXrAQ==}
+  '@yuku-codegen/binding-freebsd-x64@0.6.3':
+    resolution: {integrity: sha512-2+SFpfem2GBH6BlCTAq6R44bZwuieduwRWHkCQnSgbK8tdEjMwB0Ix0IchryVBn6hdiWCZSTkSE3UILliRXsRQ==}
     cpu: [x64]
     os: [freebsd]
 
-  '@yuku-codegen/binding-linux-arm-gnu@0.6.1':
-    resolution: {integrity: sha512-HICjDelfEDeD6TD8OEz/Dvt8KHxJiETR+paI/Fr7eVTQbjMfRrXJz8O1qV1qGH5SHZUGl2SAw2Rp+MLtXOjCrQ==}
+  '@yuku-codegen/binding-linux-arm-gnu@0.6.3':
+    resolution: {integrity: sha512-fbxg3cBPdJ++36DXtdzcoKw2xzFov91Wxvmn1khX9MXQbDqJQLJmITZhtokcZsj4uGJe32sUmxAZnKbUtZLjmA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-arm-musl@0.6.1':
-    resolution: {integrity: sha512-pUswnwa+WOmtH2ZGOWL05kFLMNY7/TnEAryfIv1yVFzKQnmSy9TKYi3oIOxGZL3w+cdUKCZ6Q+jaD0oI10ztzA==}
+  '@yuku-codegen/binding-linux-arm-musl@0.6.3':
+    resolution: {integrity: sha512-Jk4P7kocGEisSvUFIm1VuHO3hC01LvS3sYAAmVVu1/ve5TuZ0iXyl9kIGtd1ZrgUvchgvZWNOaB+/Kq/RO63FA==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-linux-arm64-gnu@0.6.1':
-    resolution: {integrity: sha512-Zro0FOu9clLCmqCnUKzEWHAu30tss0iEfhs+KDXm9Dpm1FkIHAKu43tF6FQU2hsTA7a8xd93NGddzc2EOJFKUg==}
+  '@yuku-codegen/binding-linux-arm64-gnu@0.6.3':
+    resolution: {integrity: sha512-i1xE8Bx1YZLheWtBZHD0Mq3nAIDrhgiH7o8VB4GiCbHufKb4XKj4CqSDMWSC0RYPmn//E+UEd1NsE2NbOux1tQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-arm64-musl@0.6.1':
-    resolution: {integrity: sha512-NZaT+mp9toqWuFEA4MYW5HMRxgIa8DCqnTTnM5SrrojZgm4QoMI/mJfifVet1ZHgl/Dly5m6H6GPpq43uXVj8g==}
+  '@yuku-codegen/binding-linux-arm64-musl@0.6.3':
+    resolution: {integrity: sha512-ZeLkC6xZrlDoIJTadHfqTABTmsj2f6wCCtYBYx/RPGgdmQcGLA0NALRl7m0tnK2CT45eNRuOYzsfEZyF0XWM/A==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-linux-x64-gnu@0.6.1':
-    resolution: {integrity: sha512-M5macseSCBPvJ4yfKNyQpMc7nBQBtj39MNfMt0r+8UkTnR5qJE00JJx06puHgPxT5hnGxMAuAWZ+3a9H2ngqAw==}
+  '@yuku-codegen/binding-linux-x64-gnu@0.6.3':
+    resolution: {integrity: sha512-HNYt7zjIChPcnjZRG42CZq3Zn5mqaRo4UcFLr4mIbmGqdhX5hDDE8O8US8YgYyOUosfbBTBFdsbvFwVAx1TOkQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-x64-musl@0.6.1':
-    resolution: {integrity: sha512-liAyBZI5AbazZGeeNfWj0jCD/TE2L84hgVYh4KkjJA/N9bNzFQCDf4BvWP76nEO89r2tIGEUjbXdM4mM26riHg==}
+  '@yuku-codegen/binding-linux-x64-musl@0.6.3':
+    resolution: {integrity: sha512-/1ttT31dAQc7hGtXWSEYEgzGtakAyO2C+/GqAzIuKXlGLpNPZgXdR8LZ0iDHDalbEr3AuHIPRV43sWLUrHWdsA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-win32-arm64@0.6.1':
-    resolution: {integrity: sha512-qItzfH3x6MYChPeGfvh22rHD92WLgXQRSuwvspRVSnLvpnubEfZd+9REPRQVT2l9fIuETDCEkDNRqkDROQTkgA==}
+  '@yuku-codegen/binding-win32-arm64@0.6.3':
+    resolution: {integrity: sha512-oAArRDU1lkKg+xFEtiQ7C+/wghpqrkBrFWM05W73S+3sZz8JIHH79Q+Qh5gWls3i8vccitUgCnvln5V7xKn3XQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@yuku-codegen/binding-win32-x64@0.6.1':
-    resolution: {integrity: sha512-DFFkKROZ9ZAHmFMUFRtRTkosZds1KH8BOx5t3UpNULIjT3iuUmEx9V5pWR0xOi66sANY38Ap77nz1kOZraQxEg==}
+  '@yuku-codegen/binding-win32-x64@0.6.3':
+    resolution: {integrity: sha512-bhFDcDsvmp5KuBfWTt4carNo1E4LXH7++S8qqZgDtXVqJxs0xMm7gbuqPihA8kBbphM+NzAUm5qmq6ocfqM6kg==}
     cpu: [x64]
     os: [win32]
 
-  '@yuku-parser/binding-darwin-arm64@0.6.1':
-    resolution: {integrity: sha512-jORysyRZg5zGDgVw15LGMsjZDh7jwjpUIJRBHgFt0ir15O5pEazfvuF2dnwvrJiTF0IT1EgHAVbTAYJWwQLCjg==}
+  '@yuku-parser/binding-darwin-arm64@0.6.3':
+    resolution: {integrity: sha512-Xate6yyZgvi7da/gdnZy+Vu5jlFB0LRlb5m4MY6Y98KSQeJPZIhoVXMK2Vsl48XOmPlDIS8lge414HUVUEo+hg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@yuku-parser/binding-darwin-x64@0.6.1':
-    resolution: {integrity: sha512-dTeYFkkFlbP/WCB2DtezXas3NApOPtFlXSdssB7wGtY9wpNp4HAkVo1KBwI5mcHK0e2joyUcqTSf44mFE+q7vg==}
+  '@yuku-parser/binding-darwin-x64@0.6.3':
+    resolution: {integrity: sha512-WKMZ5UU2HBdGZDEpQoLq+21f1FlS+BjroH1FaVE6zCSeqKmZ7xRP5jIRGtQ4vCYj/k2KHgyABZ16lgK9mTe2Sg==}
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-parser/binding-freebsd-x64@0.6.1':
-    resolution: {integrity: sha512-GExDp3rebo28mt3EAjvKQs0ZC3gkznAErV0I9TUNDa9muuhvD35kft61Mpsc6+NWeE+BG+kUyKbm6iO5B6ZMMA==}
+  '@yuku-parser/binding-freebsd-x64@0.6.3':
+    resolution: {integrity: sha512-OWX8V2k4bmtl/DNwU3yz3PZa2QXiSqWN3Xk7pNB5IPt7FcJBDlnpkOcX6h3tjMS7CyKE0lMvPUwwcmWSdbjkyA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@yuku-parser/binding-linux-arm-gnu@0.6.1':
-    resolution: {integrity: sha512-a9MjABj4J0VE3Z2oROGhmeddZZrhwwrnl4ZWZOuHUhD/smDtDiNtr0LpCbKB7rEYaQ29snopOPdZ/0T3YgLglQ==}
+  '@yuku-parser/binding-linux-arm-gnu@0.6.3':
+    resolution: {integrity: sha512-/4LzmPXPaCWqIpY1j3+XVb8rbXIratqCte3A4sGEjua6aVhvVxEVAqeKlBsoGkORWLeqbpcxhgxKwOGM17eexA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm-musl@0.6.1':
-    resolution: {integrity: sha512-ctuvXJgDRKKlmJfHxT4RsTvcAcHEFNJHTCsGbtt4rluQpVDc+ezk9JvQ534ehoIfZ9T0eIHSBgqYAZ4xCatNmQ==}
+  '@yuku-parser/binding-linux-arm-musl@0.6.3':
+    resolution: {integrity: sha512-Df4jk0M/eNKKQfYzXBBKhKkmJBpB+XoX2LkMxmlK3GN+fxUdeb8EM78wX+1+eLVl5dZNo6f7gOd6oDV0gChevw==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.6.1':
-    resolution: {integrity: sha512-vRtyoTtT0Ltowuh9LWOl/ZNU9h79J89ilOz5SEGspcw0jfhoUt19i07VNitll4jjfg5p2EN00q+MqX0pAobrFw==}
+  '@yuku-parser/binding-linux-arm64-gnu@0.6.3':
+    resolution: {integrity: sha512-sRCtDktUgIbbV78SYX3wdGVVm1Hz/nSUS24JgXB4MzUeGNwBNB+eQAWMtBxCGriyJNXK3zwfj+SSgvTmUdPf/A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm64-musl@0.6.1':
-    resolution: {integrity: sha512-vCsc3GOe1ylmRyfo/WLjIhjiCmaTtJbWNF4ZtgjNegDjpsRsFuCcP9duXB41QcfnJK38repKVFqFh0LR3l48FA==}
+  '@yuku-parser/binding-linux-arm64-musl@0.6.3':
+    resolution: {integrity: sha512-3J/jV3ROSqlhLyB/6i5EUHxjkom5i59iPvrtiAsnAjHzMsZJJPEke9LSaOsB0rf4MJFH9AmjvsK8gDahTjZy+A==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-x64-gnu@0.6.1':
-    resolution: {integrity: sha512-gw3d81RdUHSYwjDW2IG6gEtm4VDoPP4ZOqpuC6Nc8+UBfos+4gTWOgzmuxIOVhkSV2fJCcUDpSJIlPzEU0FLZw==}
+  '@yuku-parser/binding-linux-x64-gnu@0.6.3':
+    resolution: {integrity: sha512-a5mPn/OMSq2Aa2i7eJXcc37Jtw0b89gDO2mDpXN769b06IirEiqOzLNNJd6R7R8DxoadHzY0nLFhYNChE+jyAg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-x64-musl@0.6.1':
-    resolution: {integrity: sha512-nzU+Doq9UgZvYYvald36lZJ2Neeyheije6WE/YpoFt/oJiNmnjArRgr2CMtb/7gWBl80YSMwcHK4Ju0E+7wfWg==}
+  '@yuku-parser/binding-linux-x64-musl@0.6.3':
+    resolution: {integrity: sha512-kQSjfa6zdvotuXEGNKQ9vZZxE+lcEEbTUMSuvY/5+0crlwBCjEqrf9/W9ViFDoQAEt8WJiu/mtVNYkKAOkjLmA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-win32-arm64@0.6.1':
-    resolution: {integrity: sha512-r3tXFVDliWCPe7TL6DVxUkT4rkqnXyeFVSEDf+V9My6Gztq99/gIe3POQqFbshTRuSrpEYMGMbGxeFh+m+stxA==}
+  '@yuku-parser/binding-win32-arm64@0.6.3':
+    resolution: {integrity: sha512-ZawdN3R0YKr48BeXCpbax+WDWbgEG6nWyDosVeZasrT5TjgfF4XMP5SfuyMNvRJ4gbTitrcYHZkENSXZ9ncqcg==}
     cpu: [arm64]
     os: [win32]
 
-  '@yuku-parser/binding-win32-x64@0.6.1':
-    resolution: {integrity: sha512-FqYMOqeCS2XTdn5yvaKlOhtSQ84mVO3aTXp6LGfMd9Zq8RsV4H8qLWv+sxJsgPCXfuBV64u8/f+CTr3uIwNLWA==}
+  '@yuku-parser/binding-win32-x64@0.6.3':
+    resolution: {integrity: sha512-NcqZwBXQhKyfC0Eb+yBxXQcPjZoUstD1Dbr3X4UlOD1QiYfnvAYRKCZJ6nQ6KQ5p30dGaKkQeBL4t3qQtDQNWA==}
     cpu: [x64]
     os: [win32]
 
@@ -1241,14 +1241,14 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rolldown-plugin-dts@0.27.8:
-    resolution: {integrity: sha512-IjBTFpkrYYJPRUmIjUJFsZdR1zeHskFcEwFDzSfFDoC2pZcSNgLrBUcDFY9K0Q+A1TZJR3q9MlVomxMDP8AuLQ==}
+  rolldown-plugin-dts@0.27.9:
+    resolution: {integrity: sha512-d54yt65+ZF/Mk8H6P36As02PAMdaiWRSzVNtJRc1h7nCgUFjuRI4cN2DyTfJyfVpPH6pgy7/2D7YQH1/Rh75Yg==}
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
-      '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
+      '@typescript/native-preview': '*'
       rolldown: ^1.0.0
-      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ~7.0.0
       vue-tsc: ~3.2.0 || ~3.3.0
     peerDependenciesMeta:
       '@ts-macro/tsc':
@@ -1370,14 +1370,14 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  tsdown@0.22.7:
-    resolution: {integrity: sha512-4egbOzc9dxVv/QS+gDV75FIxDIjQQeOnXBlUuikyjmn0ozuc6FW11djJjEEo3vqkuJRygpnKHurnj+Iwftk4VA==}
+  tsdown@0.22.8:
+    resolution: {integrity: sha512-6FOLlr1iLcE3LheqQt13hVUWtTduJNwF2akPskPe8Tf1hr+N5UULHzrNZYTMNwL6lr2UyQ8iefVBB6tdqp1PCQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.22.7
-      '@tsdown/exe': 0.22.7
+      '@tsdown/css': 0.22.8
+      '@tsdown/exe': 0.22.8
       '@vitejs/devtools': '*'
       publint: ^0.3.8
       tsx: '*'
@@ -1529,8 +1529,8 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -1549,49 +1549,49 @@ packages:
   yuku-ast@0.1.7:
     resolution: {integrity: sha512-2RiMEWv500TixY5rJy6OZd4fSy9WYZKWh6gGbIJ7y7vAGcuCugWOWwOLGaQcRZrXcPUfqtLtvpaJ3SdXtWlhKA==}
 
-  yuku-codegen@0.6.1:
-    resolution: {integrity: sha512-6RJqqON2xYhMEp/sZv5oOSI3uOpWwRwzAi2fc/rMcRFjcqedAC5Fyp4AD9Vn2b8SB7hf9ESqVW+YwbDs/KvyKA==}
+  yuku-codegen@0.6.3:
+    resolution: {integrity: sha512-3c9H521tf1RRDu4cNUySfH01sKlALve4HKu2sITk33gLl5HhsvI6ngSuarpWxMPAiJEgqJc/HTvojWQRnYm9/g==}
 
-  yuku-parser@0.6.1:
-    resolution: {integrity: sha512-dPE3/+H2VBw9LhjoIVeW/axKidYGd+XzNtrwGGseZ0325cQFl0Dpwyh0R74XWe/WqQn4M8CR5YApsv2KF2zN1A==}
+  yuku-parser@0.6.3:
+    resolution: {integrity: sha512-iI6uABvvup9mvv8Mcpz7Tp//gehQlvcSnX4A4/0bf9i6X3RVQDuVUZel8jdpljwlF7WrbKsvD19y55Mc6+sKZw==}
 
 snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@biomejs/biome@2.5.3':
+  '@biomejs/biome@2.5.4':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.3
-      '@biomejs/cli-darwin-x64': 2.5.3
-      '@biomejs/cli-linux-arm64': 2.5.3
-      '@biomejs/cli-linux-arm64-musl': 2.5.3
-      '@biomejs/cli-linux-x64': 2.5.3
-      '@biomejs/cli-linux-x64-musl': 2.5.3
-      '@biomejs/cli-win32-arm64': 2.5.3
-      '@biomejs/cli-win32-x64': 2.5.3
+      '@biomejs/cli-darwin-arm64': 2.5.4
+      '@biomejs/cli-darwin-x64': 2.5.4
+      '@biomejs/cli-linux-arm64': 2.5.4
+      '@biomejs/cli-linux-arm64-musl': 2.5.4
+      '@biomejs/cli-linux-x64': 2.5.4
+      '@biomejs/cli-linux-x64-musl': 2.5.4
+      '@biomejs/cli-win32-arm64': 2.5.4
+      '@biomejs/cli-win32-x64': 2.5.4
 
-  '@biomejs/cli-darwin-arm64@2.5.3':
+  '@biomejs/cli-darwin-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.3':
+  '@biomejs/cli-darwin-x64@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.3':
+  '@biomejs/cli-linux-arm64-musl@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.3':
+  '@biomejs/cli-linux-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.3':
+  '@biomejs/cli-linux-x64-musl@2.5.4':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.3':
+  '@biomejs/cli-linux-x64@2.5.4':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.3':
+  '@biomejs/cli-win32-arm64@2.5.4':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.3':
+  '@biomejs/cli-win32-x64@2.5.4':
     optional: true
 
   '@changesets/apply-release-plan@7.1.1':
@@ -2059,70 +2059,70 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@yuku-codegen/binding-darwin-arm64@0.6.1':
+  '@yuku-codegen/binding-darwin-arm64@0.6.3':
     optional: true
 
-  '@yuku-codegen/binding-darwin-x64@0.6.1':
+  '@yuku-codegen/binding-darwin-x64@0.6.3':
     optional: true
 
-  '@yuku-codegen/binding-freebsd-x64@0.6.1':
+  '@yuku-codegen/binding-freebsd-x64@0.6.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm-gnu@0.6.1':
+  '@yuku-codegen/binding-linux-arm-gnu@0.6.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm-musl@0.6.1':
+  '@yuku-codegen/binding-linux-arm-musl@0.6.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm64-gnu@0.6.1':
+  '@yuku-codegen/binding-linux-arm64-gnu@0.6.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm64-musl@0.6.1':
+  '@yuku-codegen/binding-linux-arm64-musl@0.6.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-x64-gnu@0.6.1':
+  '@yuku-codegen/binding-linux-x64-gnu@0.6.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-x64-musl@0.6.1':
+  '@yuku-codegen/binding-linux-x64-musl@0.6.3':
     optional: true
 
-  '@yuku-codegen/binding-win32-arm64@0.6.1':
+  '@yuku-codegen/binding-win32-arm64@0.6.3':
     optional: true
 
-  '@yuku-codegen/binding-win32-x64@0.6.1':
+  '@yuku-codegen/binding-win32-x64@0.6.3':
     optional: true
 
-  '@yuku-parser/binding-darwin-arm64@0.6.1':
+  '@yuku-parser/binding-darwin-arm64@0.6.3':
     optional: true
 
-  '@yuku-parser/binding-darwin-x64@0.6.1':
+  '@yuku-parser/binding-darwin-x64@0.6.3':
     optional: true
 
-  '@yuku-parser/binding-freebsd-x64@0.6.1':
+  '@yuku-parser/binding-freebsd-x64@0.6.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-gnu@0.6.1':
+  '@yuku-parser/binding-linux-arm-gnu@0.6.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-musl@0.6.1':
+  '@yuku-parser/binding-linux-arm-musl@0.6.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.6.1':
+  '@yuku-parser/binding-linux-arm64-gnu@0.6.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-musl@0.6.1':
+  '@yuku-parser/binding-linux-arm64-musl@0.6.3':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-gnu@0.6.1':
+  '@yuku-parser/binding-linux-x64-gnu@0.6.3':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-musl@0.6.1':
+  '@yuku-parser/binding-linux-x64-musl@0.6.3':
     optional: true
 
-  '@yuku-parser/binding-win32-arm64@0.6.1':
+  '@yuku-parser/binding-win32-arm64@0.6.3':
     optional: true
 
-  '@yuku-parser/binding-win32-x64@0.6.1':
+  '@yuku-parser/binding-win32-x64@0.6.3':
     optional: true
 
   '@yuku-toolchain/types@0.5.43': {}
@@ -2531,15 +2531,15 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.27.8(rolldown@1.1.5)(typescript@7.0.2):
+  rolldown-plugin-dts@0.27.9(rolldown@1.1.5)(typescript@7.0.2):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.3
       rolldown: 1.1.5
       yuku-ast: 0.1.7
-      yuku-codegen: 0.6.1
-      yuku-parser: 0.6.1
+      yuku-codegen: 0.6.3
+      yuku-parser: 0.6.3
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
@@ -2651,7 +2651,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.22.7(tsx@4.23.1)(typescript@7.0.2):
+  tsdown@0.22.8(tsx@4.23.1)(typescript@7.0.2):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -2662,7 +2662,7 @@ snapshots:
       obug: 2.1.3
       picomatch: 4.0.5
       rolldown: 1.1.5
-      rolldown-plugin-dts: 0.27.8(rolldown@1.1.5)(typescript@7.0.2)
+      rolldown-plugin-dts: 0.27.9(rolldown@1.1.5)(typescript@7.0.2)
       semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -2780,7 +2780,7 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  ws@8.21.0: {}
+  ws@8.21.1: {}
 
   yaml@2.9.0:
     optional: true
@@ -2789,34 +2789,34 @@ snapshots:
     dependencies:
       '@yuku-toolchain/types': 0.5.43
 
-  yuku-codegen@0.6.1:
+  yuku-codegen@0.6.3:
     dependencies:
       '@yuku-toolchain/types': 0.5.43
     optionalDependencies:
-      '@yuku-codegen/binding-darwin-arm64': 0.6.1
-      '@yuku-codegen/binding-darwin-x64': 0.6.1
-      '@yuku-codegen/binding-freebsd-x64': 0.6.1
-      '@yuku-codegen/binding-linux-arm-gnu': 0.6.1
-      '@yuku-codegen/binding-linux-arm-musl': 0.6.1
-      '@yuku-codegen/binding-linux-arm64-gnu': 0.6.1
-      '@yuku-codegen/binding-linux-arm64-musl': 0.6.1
-      '@yuku-codegen/binding-linux-x64-gnu': 0.6.1
-      '@yuku-codegen/binding-linux-x64-musl': 0.6.1
-      '@yuku-codegen/binding-win32-arm64': 0.6.1
-      '@yuku-codegen/binding-win32-x64': 0.6.1
+      '@yuku-codegen/binding-darwin-arm64': 0.6.3
+      '@yuku-codegen/binding-darwin-x64': 0.6.3
+      '@yuku-codegen/binding-freebsd-x64': 0.6.3
+      '@yuku-codegen/binding-linux-arm-gnu': 0.6.3
+      '@yuku-codegen/binding-linux-arm-musl': 0.6.3
+      '@yuku-codegen/binding-linux-arm64-gnu': 0.6.3
+      '@yuku-codegen/binding-linux-arm64-musl': 0.6.3
+      '@yuku-codegen/binding-linux-x64-gnu': 0.6.3
+      '@yuku-codegen/binding-linux-x64-musl': 0.6.3
+      '@yuku-codegen/binding-win32-arm64': 0.6.3
+      '@yuku-codegen/binding-win32-x64': 0.6.3
 
-  yuku-parser@0.6.1:
+  yuku-parser@0.6.3:
     dependencies:
       '@yuku-toolchain/types': 0.5.43
     optionalDependencies:
-      '@yuku-parser/binding-darwin-arm64': 0.6.1
-      '@yuku-parser/binding-darwin-x64': 0.6.1
-      '@yuku-parser/binding-freebsd-x64': 0.6.1
-      '@yuku-parser/binding-linux-arm-gnu': 0.6.1
-      '@yuku-parser/binding-linux-arm-musl': 0.6.1
-      '@yuku-parser/binding-linux-arm64-gnu': 0.6.1
-      '@yuku-parser/binding-linux-arm64-musl': 0.6.1
-      '@yuku-parser/binding-linux-x64-gnu': 0.6.1
-      '@yuku-parser/binding-linux-x64-musl': 0.6.1
-      '@yuku-parser/binding-win32-arm64': 0.6.1
-      '@yuku-parser/binding-win32-x64': 0.6.1
+      '@yuku-parser/binding-darwin-arm64': 0.6.3
+      '@yuku-parser/binding-darwin-x64': 0.6.3
+      '@yuku-parser/binding-freebsd-x64': 0.6.3
+      '@yuku-parser/binding-linux-arm-gnu': 0.6.3
+      '@yuku-parser/binding-linux-arm-musl': 0.6.3
+      '@yuku-parser/binding-linux-arm64-gnu': 0.6.3
+      '@yuku-parser/binding-linux-arm64-musl': 0.6.3
+      '@yuku-parser/binding-linux-x64-gnu': 0.6.3
+      '@yuku-parser/binding-linux-x64-musl': 0.6.3
+      '@yuku-parser/binding-win32-arm64': 0.6.3
+      '@yuku-parser/binding-win32-x64': 0.6.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ importers:
         version: 8.21.1
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.4
-        version: 2.5.4
+        specifier: ^2.5.5
+        version: 2.5.5
       '@changesets/cli':
-        specifier: ^2.31.0
-        version: 2.31.0(@types/node@26.1.1)
+        specifier: ^2.31.1
+        version: 2.31.1(@types/node@26.1.1)
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
@@ -28,11 +28,11 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       lint-staged:
-        specifier: ^17.0.8
-        version: 17.0.8
+        specifier: ^17.2.0
+        version: 17.2.0
       tsdown:
-        specifier: ^0.22.8
-        version: 0.22.8(tsx@4.23.1)(typescript@7.0.2)
+        specifier: ^0.22.14
+        version: 0.22.14(tsx@4.23.1)(typescript@7.0.2)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -49,59 +49,59 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.5.4':
-    resolution: {integrity: sha512-xy5FNE5kQJKyK5MR1gJy6ztXYx4WBAbYGlK04lMEgmyPRWKybY9NFwiG9yo0XdzOU8Xvhj41u034J1ywfoWfMw==}
+  '@biomejs/biome@2.5.5':
+    resolution: {integrity: sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.4':
-    resolution: {integrity: sha512-4o3NFRobXHynkgcFVrlZsoDAFtF2ldlEGN8sORSws5ZQqyY4PXnPUIylu4ksfyHuwkfvDREuWh3JK+niRwGq3w==}
+  '@biomejs/cli-darwin-arm64@2.5.5':
+    resolution: {integrity: sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.4':
-    resolution: {integrity: sha512-D32P5HkU2Y6PySuC/WsVDTOgsDwVFmujzhhhOQjajtATpVWFDXuVd3oRbsWNSEA+aaFzyzZm22szsyydBYlSyQ==}
+  '@biomejs/cli-darwin-x64@2.5.5':
+    resolution: {integrity: sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.4':
-    resolution: {integrity: sha512-Rpm5/AT1m+DlJmUoYvS4/vXc+0tXJPJ2NQz25TGPyHVF5JrWy75PE0GH6kVxsKtQDuCH4OgzquZq0R4kj/wCVg==}
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
+    resolution: {integrity: sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.4':
-    resolution: {integrity: sha512-pSEfW7B8kTsXUjUxC1xVVK+y85Ht3C5XxZ9gclmC7/3Ku9Vqz8jmI7k0p/BNIjQ6t4sFERI2sFeH73ybiZl6YQ==}
+  '@biomejs/cli-linux-arm64@2.5.5':
+    resolution: {integrity: sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.4':
-    resolution: {integrity: sha512-aby/PohmmgbShcHqFsZVzG8H6D98+P+A6xRWRrQcLW1pCjabcov5UUlke4UqNQBYTkDQav+jB4zyyDDeKB2GaA==}
+  '@biomejs/cli-linux-x64-musl@2.5.5':
+    resolution: {integrity: sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.4':
-    resolution: {integrity: sha512-FNxojWJkL7EajAuzBgoLe0T2G0y112M4lBrDIFl/DomFTx8yqenYOIdsRLNXvOvBBofE8hJi85LjzLmBDpY7/Q==}
+  '@biomejs/cli-linux-x64@2.5.5':
+    resolution: {integrity: sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.4':
-    resolution: {integrity: sha512-emoXexPZIPAZkz2RKmA95WJUqK3I5MJNYtwEbL5ESciRzhmFMMyekDhNG8hpeOaK+ZGRDxAU4wvGuA5IHQ0h0w==}
+  '@biomejs/cli-win32-arm64@2.5.5':
+    resolution: {integrity: sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.4':
-    resolution: {integrity: sha512-U1jaluLw1qQc2Tx7/CeSoL9N5XcqIH+GWjpUAy1ouB5nVjSCMNO+NNHdY3RAs8zxNurLWAdj6pehQdCA2zyU+Q==}
+  '@biomejs/cli-win32-x64@2.5.5':
+    resolution: {integrity: sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -115,8 +115,8 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/cli@2.31.0':
-    resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
+  '@changesets/cli@2.31.1':
+    resolution: {integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==}
     hasBin: true
 
   '@changesets/config@3.1.4':
@@ -164,8 +164,14 @@ packages:
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -365,11 +371,20 @@ packages:
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
+  '@oxc-project/types@0.140.0':
+    resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
+
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.0':
+    resolution: {integrity: sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -380,8 +395,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rolldown/binding-darwin-x64@1.1.5':
     resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -392,14 +419,33 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@rolldown/binding-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.1.5':
     resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -412,8 +458,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
+    resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -426,8 +486,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
+    resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.1.5':
     resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -440,8 +514,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-openharmony-arm64@1.1.5':
     resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.2.0':
+    resolution: {integrity: sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -451,14 +538,31 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.2.0':
+    resolution: {integrity: sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.1.5':
     resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.1.5':
     resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -639,150 +743,138 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
-  '@yuku-codegen/binding-darwin-arm64@0.6.3':
-    resolution: {integrity: sha512-pbDcFygFmbvo0jGFq5U0m5Sa9U8aVttVJWbBHZDZ68w/X48HdDWS1V4XvBacs8XkmWbTr/ef5fMGG7HsngqTmg==}
+  '@yuku-codegen/binding-darwin-arm64@0.7.4':
+    resolution: {integrity: sha512-fjkATm+fg4r6Ss8o82u3j33PfIqhSs4A0WEEw9kOwhMx/ui/RQ0ZAsCtF6e7UG2CWGOGXAJspLlfk2tr3rjjKQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@yuku-codegen/binding-darwin-x64@0.6.3':
-    resolution: {integrity: sha512-qZMrnA4i8OfqL3NMGoOvLdh1vby8cCGsmNo+tJQIIezXO557m3fdQLenz/57GqtBnnGWzWqd/aDp+faNxWlLwQ==}
+  '@yuku-codegen/binding-darwin-x64@0.7.4':
+    resolution: {integrity: sha512-Hj0KvHpS1RJY/bgM3BADzmXXkKO3+bq3M8bMq4b0j0LsVi1SeWYpD/hJLJFwHeNMS+jO4vlZ343yjb4DEb9XXQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-codegen/binding-freebsd-x64@0.6.3':
-    resolution: {integrity: sha512-2+SFpfem2GBH6BlCTAq6R44bZwuieduwRWHkCQnSgbK8tdEjMwB0Ix0IchryVBn6hdiWCZSTkSE3UILliRXsRQ==}
+  '@yuku-codegen/binding-freebsd-x64@0.7.4':
+    resolution: {integrity: sha512-GLKBZvqVFvC1bvNPoPZRj0UxUaAZZKCzb8IPNyvRhXesOk+Af9UbhbVPwx9Do4o2AVf6R5FPzyRWWIihQdCp+A==}
     cpu: [x64]
     os: [freebsd]
 
-  '@yuku-codegen/binding-linux-arm-gnu@0.6.3':
-    resolution: {integrity: sha512-fbxg3cBPdJ++36DXtdzcoKw2xzFov91Wxvmn1khX9MXQbDqJQLJmITZhtokcZsj4uGJe32sUmxAZnKbUtZLjmA==}
+  '@yuku-codegen/binding-linux-arm-gnu@0.7.4':
+    resolution: {integrity: sha512-CAjbJexBJUqHgIPgOCJO7EYRnFluNLt5VD3jNS40wmsNZqa04HbewVVcgfmzfzuBhjX6ookntLDG3lWieyTAVw==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-arm-musl@0.6.3':
-    resolution: {integrity: sha512-Jk4P7kocGEisSvUFIm1VuHO3hC01LvS3sYAAmVVu1/ve5TuZ0iXyl9kIGtd1ZrgUvchgvZWNOaB+/Kq/RO63FA==}
+  '@yuku-codegen/binding-linux-arm-musl@0.7.4':
+    resolution: {integrity: sha512-HQMuKBltnKFUqhUh8wNiivd76coRwDngdCxbcAULlatAlc2OXo8L6jLTkVnNeUuOw9JYzSq9LY2/7zvrg63Ddg==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-linux-arm64-gnu@0.6.3':
-    resolution: {integrity: sha512-i1xE8Bx1YZLheWtBZHD0Mq3nAIDrhgiH7o8VB4GiCbHufKb4XKj4CqSDMWSC0RYPmn//E+UEd1NsE2NbOux1tQ==}
+  '@yuku-codegen/binding-linux-arm64-gnu@0.7.4':
+    resolution: {integrity: sha512-cnU7ZVxK/Oq/TIS2iq56rouy1dqnLYgWR2puWcrxGCtmbdxiMISANYhI5t2tMLzTGZMyhawM2zYlyI+gnpBupQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-arm64-musl@0.6.3':
-    resolution: {integrity: sha512-ZeLkC6xZrlDoIJTadHfqTABTmsj2f6wCCtYBYx/RPGgdmQcGLA0NALRl7m0tnK2CT45eNRuOYzsfEZyF0XWM/A==}
+  '@yuku-codegen/binding-linux-arm64-musl@0.7.4':
+    resolution: {integrity: sha512-NyuabTumcxPtZv/Q+pMVvrcKxLn1SPcpdBGtekVJz7JwI36SuExTq4IG4EZsk7YDmFKP8wDEvmKYOpV/a8Lwhw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-linux-x64-gnu@0.6.3':
-    resolution: {integrity: sha512-HNYt7zjIChPcnjZRG42CZq3Zn5mqaRo4UcFLr4mIbmGqdhX5hDDE8O8US8YgYyOUosfbBTBFdsbvFwVAx1TOkQ==}
+  '@yuku-codegen/binding-linux-x64-gnu@0.7.4':
+    resolution: {integrity: sha512-w3EnCLPD2vpJw0F+0qVV/1KSOAw4SgzjbGUbbwXUh9w5Kxo1Hdc3mN+/Nvk50oA6cCbSOCEaILnPHXPCauArvg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-x64-musl@0.6.3':
-    resolution: {integrity: sha512-/1ttT31dAQc7hGtXWSEYEgzGtakAyO2C+/GqAzIuKXlGLpNPZgXdR8LZ0iDHDalbEr3AuHIPRV43sWLUrHWdsA==}
+  '@yuku-codegen/binding-linux-x64-musl@0.7.4':
+    resolution: {integrity: sha512-FXKQlFjDM8FxqJ/TncAni7e7JyaXIB3Hv6boApxSs5ZUlvqP4TbrjYVk3mYDQt6xQAE/kEHplxM6m5SKx5sfRg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-win32-arm64@0.6.3':
-    resolution: {integrity: sha512-oAArRDU1lkKg+xFEtiQ7C+/wghpqrkBrFWM05W73S+3sZz8JIHH79Q+Qh5gWls3i8vccitUgCnvln5V7xKn3XQ==}
+  '@yuku-codegen/binding-win32-arm64@0.7.4':
+    resolution: {integrity: sha512-rWr899KEvZIWMx9yUXQl4i90OGIs4gaw4X1UsS2rxsI3qnp8acLIVKI3N5WDqaertkW10crDRZvIxxyw7kTMTQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@yuku-codegen/binding-win32-x64@0.6.3':
-    resolution: {integrity: sha512-bhFDcDsvmp5KuBfWTt4carNo1E4LXH7++S8qqZgDtXVqJxs0xMm7gbuqPihA8kBbphM+NzAUm5qmq6ocfqM6kg==}
+  '@yuku-codegen/binding-win32-x64@0.7.4':
+    resolution: {integrity: sha512-3Olgmkd5rDrIN9g7wJFMRRC9jub5zAwiQOtwOVhvNe/nZE/rSufFRa7vrFupqSCQml+Zxbcy9npzo3Qne3rA2A==}
     cpu: [x64]
     os: [win32]
 
-  '@yuku-parser/binding-darwin-arm64@0.6.3':
-    resolution: {integrity: sha512-Xate6yyZgvi7da/gdnZy+Vu5jlFB0LRlb5m4MY6Y98KSQeJPZIhoVXMK2Vsl48XOmPlDIS8lge414HUVUEo+hg==}
+  '@yuku-parser/binding-darwin-arm64@0.7.4':
+    resolution: {integrity: sha512-rUetRGukIlPOkDCy+Fo0YTee66n9A04XRQMONptbemWSU27CCV6RDj56+4ne4eSE4gJ0139RWUfbqMtt744pWQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@yuku-parser/binding-darwin-x64@0.6.3':
-    resolution: {integrity: sha512-WKMZ5UU2HBdGZDEpQoLq+21f1FlS+BjroH1FaVE6zCSeqKmZ7xRP5jIRGtQ4vCYj/k2KHgyABZ16lgK9mTe2Sg==}
+  '@yuku-parser/binding-darwin-x64@0.7.4':
+    resolution: {integrity: sha512-9bHrGQUot2vWTg0YTdyIBHGd38fy2BSQH1WaqUDVuNqSn7HffrTUzWOgbaWRNd5GTOvDdrt9SDZIG7nfqzeBtg==}
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-parser/binding-freebsd-x64@0.6.3':
-    resolution: {integrity: sha512-OWX8V2k4bmtl/DNwU3yz3PZa2QXiSqWN3Xk7pNB5IPt7FcJBDlnpkOcX6h3tjMS7CyKE0lMvPUwwcmWSdbjkyA==}
+  '@yuku-parser/binding-freebsd-x64@0.7.4':
+    resolution: {integrity: sha512-159565OJ/LR6cCP781nH8DxB5GqlqqWk3uyOLZIznQhsj9zeht4X7+jz9IQH1l/TUio+ojEXf8yt2+DJrN+QVw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@yuku-parser/binding-linux-arm-gnu@0.6.3':
-    resolution: {integrity: sha512-/4LzmPXPaCWqIpY1j3+XVb8rbXIratqCte3A4sGEjua6aVhvVxEVAqeKlBsoGkORWLeqbpcxhgxKwOGM17eexA==}
+  '@yuku-parser/binding-linux-arm-gnu@0.7.4':
+    resolution: {integrity: sha512-j3s3LJxEbOyP58hmzuXpJlKzgxaswuOTu8nAbDpE119b5W3gP1SW+HndLscGUOACpyMdH5WJ6gBHRxq0HCRVBw==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm-musl@0.6.3':
-    resolution: {integrity: sha512-Df4jk0M/eNKKQfYzXBBKhKkmJBpB+XoX2LkMxmlK3GN+fxUdeb8EM78wX+1+eLVl5dZNo6f7gOd6oDV0gChevw==}
+  '@yuku-parser/binding-linux-arm-musl@0.7.4':
+    resolution: {integrity: sha512-PUpHPmvWIDxhYTS5oah08RQ28t6dlFBxRPJcftS6HgquiPsm/e0gL5vKwPJpyjaPBHzRH61IAUDDfrRe8iFs8g==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.6.3':
-    resolution: {integrity: sha512-sRCtDktUgIbbV78SYX3wdGVVm1Hz/nSUS24JgXB4MzUeGNwBNB+eQAWMtBxCGriyJNXK3zwfj+SSgvTmUdPf/A==}
+  '@yuku-parser/binding-linux-arm64-gnu@0.7.4':
+    resolution: {integrity: sha512-Hi3w0et5mu3i7S+qE0UgOev4RqJ/U9DW8xn79t4nttiICYCx3NveC0Goo78uqzxttsDI3hfRY43lrrF26svqcw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm64-musl@0.6.3':
-    resolution: {integrity: sha512-3J/jV3ROSqlhLyB/6i5EUHxjkom5i59iPvrtiAsnAjHzMsZJJPEke9LSaOsB0rf4MJFH9AmjvsK8gDahTjZy+A==}
+  '@yuku-parser/binding-linux-arm64-musl@0.7.4':
+    resolution: {integrity: sha512-i073u4ENL9DJeWBRKioRCz8i5hg6EmUcH89eH1lts9f9AFPA1GphODwK6OXOXUbpi2AwZ1deFIUWgLGP2mdmmA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-x64-gnu@0.6.3':
-    resolution: {integrity: sha512-a5mPn/OMSq2Aa2i7eJXcc37Jtw0b89gDO2mDpXN769b06IirEiqOzLNNJd6R7R8DxoadHzY0nLFhYNChE+jyAg==}
+  '@yuku-parser/binding-linux-x64-gnu@0.7.4':
+    resolution: {integrity: sha512-j5pt0LyDGxCzfoqRTR3cmMG21+bgSxIufAzJXFOWXkbg/22Ih51eGEsbInnSD5Q9FvJ3ooIn/jfok0dBdhudnA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-x64-musl@0.6.3':
-    resolution: {integrity: sha512-kQSjfa6zdvotuXEGNKQ9vZZxE+lcEEbTUMSuvY/5+0crlwBCjEqrf9/W9ViFDoQAEt8WJiu/mtVNYkKAOkjLmA==}
+  '@yuku-parser/binding-linux-x64-musl@0.7.4':
+    resolution: {integrity: sha512-RR1hNhrSpv3FanLM6u5uD+9CYA9IM8U3uGscgvKKV77gtj7ttO4UubpwN7vcx1KknoEIQHKJFPVKoeVy+avf6w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-win32-arm64@0.6.3':
-    resolution: {integrity: sha512-ZawdN3R0YKr48BeXCpbax+WDWbgEG6nWyDosVeZasrT5TjgfF4XMP5SfuyMNvRJ4gbTitrcYHZkENSXZ9ncqcg==}
+  '@yuku-parser/binding-win32-arm64@0.7.4':
+    resolution: {integrity: sha512-1xhYwOLo9TjppHHwNYi3X/dGgOvnj9xh62jpgP4U8nEtTGA70NtJDCkN45pRQdU3B6/U7oQj1T4esP3aFJg6BA==}
     cpu: [arm64]
     os: [win32]
 
-  '@yuku-parser/binding-win32-x64@0.6.3':
-    resolution: {integrity: sha512-NcqZwBXQhKyfC0Eb+yBxXQcPjZoUstD1Dbr3X4UlOD1QiYfnvAYRKCZJ6nQ6KQ5p30dGaKkQeBL4t3qQtDQNWA==}
+  '@yuku-parser/binding-win32-x64@0.7.4':
+    resolution: {integrity: sha512-HonZAapmSKusxLZPnU9WrMzAUdPSBJliGw3CSkA9Er/aq15STEOEy9SOsVGvj4maBv95EmWxt2LThHXnFnGfNg==}
     cpu: [x64]
     os: [win32]
 
-  '@yuku-toolchain/types@0.5.43':
-    resolution: {integrity: sha512-kSpvPntnXw5+lYjO71ffBEnQ5ycQ74KGIYknh0TS4xeyCuBkOqxyJumxZkMhLBBUCLjDAbx2+Icnr3Zh4ftjpQ==}
+  '@yuku-toolchain/types@0.7.4':
+    resolution: {integrity: sha512-iUFXr+UnUJjzVLNI6GIv07poi9NwcG5hTBJSheJh3SdpkYpIjCl9kAGe7dbJMHn5sXeceCL4H12pKa0b6pkouQ==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
-  ansi-escapes@7.3.0:
-    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
-    engines: {node: '>=18'}
-
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
 
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
@@ -821,14 +913,6 @@ packages:
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
-
-  cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -860,9 +944,6 @@ packages:
       oxc-resolver:
         optional: true
 
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
     engines: {node: '>=14'}
@@ -870,10 +951,6 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
-
-  environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
@@ -890,9 +967,6 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
-
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
@@ -938,10 +1012,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  get-east-asian-width@1.6.0:
-    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
-    engines: {node: '>=18'}
-
   get-tsconfig@5.0.0-beta.5:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
@@ -984,10 +1054,6 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1093,14 +1159,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
-  lint-staged@17.0.8:
-    resolution: {integrity: sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==}
+  lint-staged@17.2.0:
+    resolution: {integrity: sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A==}
     engines: {node: '>=22.22.1'}
     hasBin: true
-
-  listr2@10.2.2:
-    resolution: {integrity: sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==}
-    engines: {node: '>=22.13.0'}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -1108,10 +1170,6 @@ packages:
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-
-  log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1124,10 +1182,6 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -1137,13 +1191,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  obug@2.1.3:
-    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
-
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -1230,30 +1280,23 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  rolldown-plugin-dts@0.27.9:
-    resolution: {integrity: sha512-d54yt65+ZF/Mk8H6P36As02PAMdaiWRSzVNtJRc1h7nCgUFjuRI4cN2DyTfJyfVpPH6pgy7/2D7YQH1/Rh75Yg==}
+  rolldown-plugin-dts@0.27.13:
+    resolution: {integrity: sha512-DeVZJbbB0ajp5q6vABqC8ZCJzxftlxbiV60Bk96GFdQaysGVpgTTVjQu0lUt4Lb+aRCtejfOixtQKDRol7IuVQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
-      '@ts-macro/tsc': ^0.3.6
       '@typescript/native-preview': '*'
+      '@volar/typescript': ~2.4.0
       rolldown: ^1.0.0
       typescript: ^5.0.0 || ^6.0.0 || ~7.0.0
       vue-tsc: ~3.2.0 || ~3.3.0
     peerDependenciesMeta:
-      '@ts-macro/tsc':
-        optional: true
       '@typescript/native-preview':
+        optional: true
+      '@volar/typescript':
         optional: true
       typescript:
         optional: true
@@ -1262,6 +1305,11 @@ packages:
 
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.2.0:
+    resolution: {integrity: sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1295,14 +1343,6 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
-
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1323,21 +1363,9 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
-  string-width@8.2.2:
-    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
-    engines: {node: '>=20'}
-
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -1370,14 +1398,14 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  tsdown@0.22.8:
-    resolution: {integrity: sha512-6FOLlr1iLcE3LheqQt13hVUWtTduJNwF2akPskPe8Tf1hr+N5UULHzrNZYTMNwL6lr2UyQ8iefVBB6tdqp1PCQ==}
+  tsdown@0.22.14:
+    resolution: {integrity: sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.22.8
-      '@tsdown/exe': 0.22.8
+      '@tsdown/css': 0.22.14
+      '@tsdown/exe': 0.22.14
       '@vitejs/devtools': '*'
       publint: ^0.3.8
       tsx: '*'
@@ -1426,6 +1454,10 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  verkit@0.3.0:
+    resolution: {integrity: sha512-Njrh4U8UODGajoZ44QS2C/BsoEM9DTI/aCqY5swsizb+/ap0FamvnCMcZAxrR5+aoC0ZqkawEfpC/N2SBc+xeA==}
+    engines: {node: '>=18.12.0'}
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -1521,14 +1553,6 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wrap-ansi@10.0.0:
-    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
-    engines: {node: '>=20'}
-
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
-
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
@@ -1546,52 +1570,52 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yuku-ast@0.1.7:
-    resolution: {integrity: sha512-2RiMEWv500TixY5rJy6OZd4fSy9WYZKWh6gGbIJ7y7vAGcuCugWOWwOLGaQcRZrXcPUfqtLtvpaJ3SdXtWlhKA==}
+  yuku-ast@0.7.4:
+    resolution: {integrity: sha512-Pn6e7uZOBczeJ+JIiPGtD4aw6eRflzKrZJmAdeg092RxM9tQtvAkZAbEoknNgYmsB6dGYESvXPQcUE7Nu8ai7Q==}
 
-  yuku-codegen@0.6.3:
-    resolution: {integrity: sha512-3c9H521tf1RRDu4cNUySfH01sKlALve4HKu2sITk33gLl5HhsvI6ngSuarpWxMPAiJEgqJc/HTvojWQRnYm9/g==}
+  yuku-codegen@0.7.4:
+    resolution: {integrity: sha512-bLdC5yzvn507PtU7+kB4CMBLfnvKW1N2m26Vpl1q4Os+FLROnkKTThM7g+clVb+9tHaOlcc6gqQ+rNBY8L/Dxw==}
 
-  yuku-parser@0.6.3:
-    resolution: {integrity: sha512-iI6uABvvup9mvv8Mcpz7Tp//gehQlvcSnX4A4/0bf9i6X3RVQDuVUZel8jdpljwlF7WrbKsvD19y55Mc6+sKZw==}
+  yuku-parser@0.7.4:
+    resolution: {integrity: sha512-HveMyhZPQQfR4z3xskXv5hHJW9g0KIESZW6JvUZv7Jn52FfMFUhCYL77KHBtnWGFti0KrKeTHMZVTY5AUVgFAA==}
 
 snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@biomejs/biome@2.5.4':
+  '@biomejs/biome@2.5.5':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.4
-      '@biomejs/cli-darwin-x64': 2.5.4
-      '@biomejs/cli-linux-arm64': 2.5.4
-      '@biomejs/cli-linux-arm64-musl': 2.5.4
-      '@biomejs/cli-linux-x64': 2.5.4
-      '@biomejs/cli-linux-x64-musl': 2.5.4
-      '@biomejs/cli-win32-arm64': 2.5.4
-      '@biomejs/cli-win32-x64': 2.5.4
+      '@biomejs/cli-darwin-arm64': 2.5.5
+      '@biomejs/cli-darwin-x64': 2.5.5
+      '@biomejs/cli-linux-arm64': 2.5.5
+      '@biomejs/cli-linux-arm64-musl': 2.5.5
+      '@biomejs/cli-linux-x64': 2.5.5
+      '@biomejs/cli-linux-x64-musl': 2.5.5
+      '@biomejs/cli-win32-arm64': 2.5.5
+      '@biomejs/cli-win32-x64': 2.5.5
 
-  '@biomejs/cli-darwin-arm64@2.5.4':
+  '@biomejs/cli-darwin-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.4':
+  '@biomejs/cli-darwin-x64@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.4':
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.4':
+  '@biomejs/cli-linux-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.4':
+  '@biomejs/cli-linux-x64-musl@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.4':
+  '@biomejs/cli-linux-x64@2.5.5':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.4':
+  '@biomejs/cli-win32-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.4':
+  '@biomejs/cli-win32-x64@2.5.5':
     optional: true
 
   '@changesets/apply-release-plan@7.1.1':
@@ -1623,7 +1647,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.31.0(@types/node@26.1.1)':
+  '@changesets/cli@2.31.1(@types/node@26.1.1)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -1743,7 +1767,18 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -1863,6 +1898,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1877,6 +1919,8 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
+  '@oxc-project/types@0.140.0': {}
+
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
@@ -1884,37 +1928,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.2.0':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.0':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.1.5':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.2.0':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.1.5':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.2.0':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.0':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.5':
@@ -1924,10 +2004,23 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.2.0':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.1.5':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -2059,85 +2152,77 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@yuku-codegen/binding-darwin-arm64@0.6.3':
+  '@yuku-codegen/binding-darwin-arm64@0.7.4':
     optional: true
 
-  '@yuku-codegen/binding-darwin-x64@0.6.3':
+  '@yuku-codegen/binding-darwin-x64@0.7.4':
     optional: true
 
-  '@yuku-codegen/binding-freebsd-x64@0.6.3':
+  '@yuku-codegen/binding-freebsd-x64@0.7.4':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm-gnu@0.6.3':
+  '@yuku-codegen/binding-linux-arm-gnu@0.7.4':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm-musl@0.6.3':
+  '@yuku-codegen/binding-linux-arm-musl@0.7.4':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm64-gnu@0.6.3':
+  '@yuku-codegen/binding-linux-arm64-gnu@0.7.4':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm64-musl@0.6.3':
+  '@yuku-codegen/binding-linux-arm64-musl@0.7.4':
     optional: true
 
-  '@yuku-codegen/binding-linux-x64-gnu@0.6.3':
+  '@yuku-codegen/binding-linux-x64-gnu@0.7.4':
     optional: true
 
-  '@yuku-codegen/binding-linux-x64-musl@0.6.3':
+  '@yuku-codegen/binding-linux-x64-musl@0.7.4':
     optional: true
 
-  '@yuku-codegen/binding-win32-arm64@0.6.3':
+  '@yuku-codegen/binding-win32-arm64@0.7.4':
     optional: true
 
-  '@yuku-codegen/binding-win32-x64@0.6.3':
+  '@yuku-codegen/binding-win32-x64@0.7.4':
     optional: true
 
-  '@yuku-parser/binding-darwin-arm64@0.6.3':
+  '@yuku-parser/binding-darwin-arm64@0.7.4':
     optional: true
 
-  '@yuku-parser/binding-darwin-x64@0.6.3':
+  '@yuku-parser/binding-darwin-x64@0.7.4':
     optional: true
 
-  '@yuku-parser/binding-freebsd-x64@0.6.3':
+  '@yuku-parser/binding-freebsd-x64@0.7.4':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-gnu@0.6.3':
+  '@yuku-parser/binding-linux-arm-gnu@0.7.4':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-musl@0.6.3':
+  '@yuku-parser/binding-linux-arm-musl@0.7.4':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.6.3':
+  '@yuku-parser/binding-linux-arm64-gnu@0.7.4':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-musl@0.6.3':
+  '@yuku-parser/binding-linux-arm64-musl@0.7.4':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-gnu@0.6.3':
+  '@yuku-parser/binding-linux-x64-gnu@0.7.4':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-musl@0.6.3':
+  '@yuku-parser/binding-linux-x64-musl@0.7.4':
     optional: true
 
-  '@yuku-parser/binding-win32-arm64@0.6.3':
+  '@yuku-parser/binding-win32-arm64@0.7.4':
     optional: true
 
-  '@yuku-parser/binding-win32-x64@0.6.3':
+  '@yuku-parser/binding-win32-x64@0.7.4':
     optional: true
 
-  '@yuku-toolchain/types@0.5.43': {}
+  '@yuku-toolchain/types@0.7.4': {}
 
   ansi-colors@4.1.3: {}
 
-  ansi-escapes@7.3.0:
-    dependencies:
-      environment: 1.1.0
-
   ansi-regex@5.0.1: {}
-
-  ansi-regex@6.2.2: {}
-
-  ansi-styles@6.2.3: {}
 
   ansis@4.3.1: {}
 
@@ -2165,15 +2250,6 @@ snapshots:
 
   chardet@2.2.0: {}
 
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
-
-  cli-truncate@5.2.0:
-    dependencies:
-      slice-ansi: 8.0.0
-      string-width: 8.2.2
-
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
@@ -2194,16 +2270,12 @@ snapshots:
 
   dts-resolver@3.0.0: {}
 
-  emoji-regex@10.6.0: {}
-
   empathic@2.0.1: {}
 
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
-
-  environment@1.1.0: {}
 
   es-module-lexer@2.3.1: {}
 
@@ -2241,8 +2313,6 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
-
-  eventemitter3@5.0.4: {}
 
   expect-type@1.4.0: {}
 
@@ -2288,8 +2358,6 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  get-east-asian-width@1.6.0: {}
-
   get-tsconfig@5.0.0-beta.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -2324,10 +2392,6 @@ snapshots:
   import-without-cache@0.4.0: {}
 
   is-extglob@2.1.1: {}
-
-  is-fullwidth-code-point@5.1.0:
-    dependencies:
-      get-east-asian-width: 1.6.0
 
   is-glob@4.0.3:
     dependencies:
@@ -2405,36 +2469,19 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
-  lint-staged@17.0.8:
+  lint-staged@17.2.0:
     dependencies:
-      listr2: 10.2.2
       picomatch: 4.0.5
       string-argv: 0.3.2
       tinyexec: 1.2.4
     optionalDependencies:
       yaml: 2.9.0
 
-  listr2@10.2.2:
-    dependencies:
-      cli-truncate: 5.2.0
-      eventemitter3: 5.0.4
-      log-update: 6.1.0
-      rfdc: 1.4.1
-      wrap-ansi: 10.0.0
-
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
 
   lodash.startcase@4.4.0: {}
-
-  log-update@6.1.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      cli-cursor: 5.0.0
-      slice-ansi: 7.1.2
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
 
   magic-string@0.30.21:
     dependencies:
@@ -2447,17 +2494,11 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  mimic-function@5.0.1: {}
-
   mri@1.2.0: {}
 
   nanoid@3.3.15: {}
 
-  obug@2.1.3: {}
-
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
+  obug@2.1.4: {}
 
   outdent@0.5.0: {}
 
@@ -2522,24 +2563,17 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
-
   reusify@1.1.0: {}
 
-  rfdc@1.4.1: {}
-
-  rolldown-plugin-dts@0.27.9(rolldown@1.1.5)(typescript@7.0.2):
+  rolldown-plugin-dts@0.27.13(rolldown@1.2.0)(typescript@7.0.2):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
-      obug: 2.1.3
-      rolldown: 1.1.5
-      yuku-ast: 0.1.7
-      yuku-codegen: 0.6.3
-      yuku-parser: 0.6.3
+      obug: 2.1.4
+      rolldown: 1.2.0
+      yuku-ast: 0.7.4
+      yuku-codegen: 0.7.4
+      yuku-parser: 0.7.4
     optionalDependencies:
       typescript: 7.0.2
     transitivePeerDependencies:
@@ -2566,6 +2600,27 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.5
       '@rolldown/binding-win32-x64-msvc': 1.1.5
 
+  rolldown@1.2.0:
+    dependencies:
+      '@oxc-project/types': 0.140.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.0
+      '@rolldown/binding-darwin-arm64': 1.2.0
+      '@rolldown/binding-darwin-x64': 1.2.0
+      '@rolldown/binding-freebsd-x64': 1.2.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.0
+      '@rolldown/binding-linux-arm64-gnu': 1.2.0
+      '@rolldown/binding-linux-arm64-musl': 1.2.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.0
+      '@rolldown/binding-linux-s390x-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-musl': 1.2.0
+      '@rolldown/binding-openharmony-arm64': 1.2.0
+      '@rolldown/binding-wasm32-wasi': 1.2.0
+      '@rolldown/binding-win32-arm64-msvc': 1.2.0
+      '@rolldown/binding-win32-x64-msvc': 1.2.0
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -2586,16 +2641,6 @@ snapshots:
 
   slash@3.0.0: {}
 
-  slice-ansi@7.1.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
   source-map-js@1.2.1: {}
 
   spawndamnit@3.0.1:
@@ -2611,24 +2656,9 @@ snapshots:
 
   string-argv@0.3.2: {}
 
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
-  string-width@8.2.2:
-    dependencies:
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -2651,7 +2681,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.22.8(tsx@4.23.1)(typescript@7.0.2):
+  tsdown@0.22.14(tsx@4.23.1)(typescript@7.0.2):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -2659,21 +2689,21 @@ snapshots:
       empathic: 2.0.1
       hookable: 6.1.1
       import-without-cache: 0.4.0
-      obug: 2.1.3
+      obug: 2.1.4
       picomatch: 4.0.5
-      rolldown: 1.1.5
-      rolldown-plugin-dts: 0.27.9(rolldown@1.1.5)(typescript@7.0.2)
-      semver: 7.8.5
+      rolldown: 1.2.0
+      rolldown-plugin-dts: 0.27.13(rolldown@1.2.0)(typescript@7.0.2)
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
+      verkit: 0.3.0
     optionalDependencies:
       tsx: 4.23.1
       typescript: 7.0.2
     transitivePeerDependencies:
-      - '@ts-macro/tsc'
       - '@typescript/native-preview'
+      - '@volar/typescript'
       - oxc-resolver
       - vue-tsc
 
@@ -2718,6 +2748,8 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  verkit@0.3.0: {}
+
   vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -2744,7 +2776,7 @@ snapshots:
       es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
       std-env: 4.2.0
@@ -2768,55 +2800,44 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrap-ansi@10.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 8.2.2
-      strip-ansi: 7.2.0
-
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
   ws@8.21.1: {}
 
   yaml@2.9.0:
     optional: true
 
-  yuku-ast@0.1.7:
+  yuku-ast@0.7.4:
     dependencies:
-      '@yuku-toolchain/types': 0.5.43
+      '@yuku-toolchain/types': 0.7.4
 
-  yuku-codegen@0.6.3:
+  yuku-codegen@0.7.4:
     dependencies:
-      '@yuku-toolchain/types': 0.5.43
+      '@yuku-toolchain/types': 0.7.4
     optionalDependencies:
-      '@yuku-codegen/binding-darwin-arm64': 0.6.3
-      '@yuku-codegen/binding-darwin-x64': 0.6.3
-      '@yuku-codegen/binding-freebsd-x64': 0.6.3
-      '@yuku-codegen/binding-linux-arm-gnu': 0.6.3
-      '@yuku-codegen/binding-linux-arm-musl': 0.6.3
-      '@yuku-codegen/binding-linux-arm64-gnu': 0.6.3
-      '@yuku-codegen/binding-linux-arm64-musl': 0.6.3
-      '@yuku-codegen/binding-linux-x64-gnu': 0.6.3
-      '@yuku-codegen/binding-linux-x64-musl': 0.6.3
-      '@yuku-codegen/binding-win32-arm64': 0.6.3
-      '@yuku-codegen/binding-win32-x64': 0.6.3
+      '@yuku-codegen/binding-darwin-arm64': 0.7.4
+      '@yuku-codegen/binding-darwin-x64': 0.7.4
+      '@yuku-codegen/binding-freebsd-x64': 0.7.4
+      '@yuku-codegen/binding-linux-arm-gnu': 0.7.4
+      '@yuku-codegen/binding-linux-arm-musl': 0.7.4
+      '@yuku-codegen/binding-linux-arm64-gnu': 0.7.4
+      '@yuku-codegen/binding-linux-arm64-musl': 0.7.4
+      '@yuku-codegen/binding-linux-x64-gnu': 0.7.4
+      '@yuku-codegen/binding-linux-x64-musl': 0.7.4
+      '@yuku-codegen/binding-win32-arm64': 0.7.4
+      '@yuku-codegen/binding-win32-x64': 0.7.4
 
-  yuku-parser@0.6.3:
+  yuku-parser@0.7.4:
     dependencies:
-      '@yuku-toolchain/types': 0.5.43
+      '@yuku-toolchain/types': 0.7.4
+      yuku-ast: 0.7.4
     optionalDependencies:
-      '@yuku-parser/binding-darwin-arm64': 0.6.3
-      '@yuku-parser/binding-darwin-x64': 0.6.3
-      '@yuku-parser/binding-freebsd-x64': 0.6.3
-      '@yuku-parser/binding-linux-arm-gnu': 0.6.3
-      '@yuku-parser/binding-linux-arm-musl': 0.6.3
-      '@yuku-parser/binding-linux-arm64-gnu': 0.6.3
-      '@yuku-parser/binding-linux-arm64-musl': 0.6.3
-      '@yuku-parser/binding-linux-x64-gnu': 0.6.3
-      '@yuku-parser/binding-linux-x64-musl': 0.6.3
-      '@yuku-parser/binding-win32-arm64': 0.6.3
-      '@yuku-parser/binding-win32-x64': 0.6.3
+      '@yuku-parser/binding-darwin-arm64': 0.7.4
+      '@yuku-parser/binding-darwin-x64': 0.7.4
+      '@yuku-parser/binding-freebsd-x64': 0.7.4
+      '@yuku-parser/binding-linux-arm-gnu': 0.7.4
+      '@yuku-parser/binding-linux-arm-musl': 0.7.4
+      '@yuku-parser/binding-linux-arm64-gnu': 0.7.4
+      '@yuku-parser/binding-linux-arm64-musl': 0.7.4
+      '@yuku-parser/binding-linux-x64-gnu': 0.7.4
+      '@yuku-parser/binding-linux-x64-musl': 0.7.4
+      '@yuku-parser/binding-win32-arm64': 0.7.4
+      '@yuku-parser/binding-win32-x64': 0.7.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,17 +2,17 @@ allowBuilds:
   esbuild: true
 
 minimumReleaseAgeExclude:
-  - '@biomejs/biome@2.5.3'
-  - '@biomejs/cli-darwin-arm64@2.5.3'
-  - '@biomejs/cli-darwin-x64@2.5.3'
-  - '@biomejs/cli-linux-arm64-musl@2.5.3'
-  - '@biomejs/cli-linux-arm64@2.5.3'
-  - '@biomejs/cli-linux-x64-musl@2.5.3'
-  - '@biomejs/cli-linux-x64@2.5.3'
-  - '@biomejs/cli-win32-arm64@2.5.3'
-  - '@biomejs/cli-win32-x64@2.5.3'
+  - '@biomejs/biome@2.5.3 || 2.5.4'
+  - '@biomejs/cli-darwin-arm64@2.5.3 || 2.5.4'
+  - '@biomejs/cli-darwin-x64@2.5.3 || 2.5.4'
+  - '@biomejs/cli-linux-arm64-musl@2.5.3 || 2.5.4'
+  - '@biomejs/cli-linux-arm64@2.5.3 || 2.5.4'
+  - '@biomejs/cli-linux-x64-musl@2.5.3 || 2.5.4'
+  - '@biomejs/cli-linux-x64@2.5.3 || 2.5.4'
+  - '@biomejs/cli-win32-arm64@2.5.3 || 2.5.4'
+  - '@biomejs/cli-win32-x64@2.5.3 || 2.5.4'
   - '@types/node@26.1.1'
-  - tsdown@0.22.4 || 0.22.5 || 0.22.7
+  - tsdown@0.22.4 || 0.22.5 || 0.22.7 || 0.22.8
   - rolldown-plugin-dts@0.27.8
   - tsx@4.23.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,8 +12,10 @@ minimumReleaseAgeExclude:
   - '@biomejs/cli-win32-arm64@2.5.3 || 2.5.4'
   - '@biomejs/cli-win32-x64@2.5.3 || 2.5.4'
   - '@types/node@26.1.1'
-  - tsdown@0.22.4 || 0.22.5 || 0.22.7 || 0.22.8
+  - tsdown@0.22.4 || 0.22.5 || 0.22.7 || 0.22.8 || 0.22.14
   - rolldown-plugin-dts@0.27.8
   - tsx@4.23.1
+  - lint-staged@17.2.0
+  - verkit@0.3.0
 
 packages: []

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,4 +18,7 @@ minimumReleaseAgeExclude:
   - lint-staged@17.2.0
   - verkit@0.3.0
 
-packages: []
+# The root is the published package. Without it listed, pnpm reports a workspace with zero packages
+# and changesets cannot find `hoshimi` to version.
+packages:
+  - .

--- a/src/classes/Hoshimi.ts
+++ b/src/classes/Hoshimi.ts
@@ -311,6 +311,13 @@ export class Hoshimi extends EventEmitter<HoshimiEvents> {
                         return;
                     }
 
+                    // Voice state updates arrive for every member of the guild; patching on someone
+                    // else's payload would overwrite the client session id with a foreign one.
+                    if ("user_id" in data && data.user_id !== this.options.client.id) {
+                        this.debug(DebugLevels.Player, "[Player] -> [Voice] The user id does not match the client id.");
+                        return;
+                    }
+
                     // this is the most funny thing i've ever made.
                     if ("session_id" in data && "channel_id" in data)
                         player.voice.patch({ channelId: data.channel_id, sessionId: data.session_id });
@@ -339,11 +346,6 @@ export class Hoshimi extends EventEmitter<HoshimiEvents> {
                             `[Player] -> [Voice] Updated the player voice for: ${data.guild_id} | Session: ${player.voice.sessionId} | Token: ${data.token} | Endpoint: ${data.endpoint}`,
                         );
 
-                        return;
-                    }
-
-                    if (data.user_id !== this.options.client.id) {
-                        this.debug(DebugLevels.Player, "[Player] -> [Voice] The user id does not match the client id.");
                         return;
                     }
 
@@ -438,7 +440,10 @@ export class Hoshimi extends EventEmitter<HoshimiEvents> {
             ...info,
         };
 
-        if (!this.options.client.id) throw new ManagerError("You must provide the client id.");
+        // The default id is a placeholder meant to be overwritten by `info`: still holding it here means
+        // no real client id was ever provided, and the node would connect with `User-Id: 0`.
+        if (!this.options.client.id || this.options.client.id === HoshimiDefaultOptions.client.id)
+            throw new ManagerError("You must provide the client id.");
         if (typeof this.options.client.id !== "string") throw new OptionError("The client info 'info.client.id': must be a string.");
 
         let amount: number = 0;

--- a/src/classes/node/Manager.ts
+++ b/src/classes/node/Manager.ts
@@ -1,5 +1,5 @@
 import { EventNames, type NodeIdentifier } from "../../types/Manager";
-import { type NodeOptions, NodeSortTypes, State } from "../../types/Node";
+import { type NodeOptions, type NodeSortFilter, NodeSortTypes, State } from "../../types/Node";
 import { type NodeStructure, Structures } from "../../types/Structures";
 import { Collection } from "../../util/collection";
 import { NodeManagerError } from "../Errors";
@@ -199,9 +199,11 @@ export class NodeManager {
      * }
      * ```
      */
-    public getLeastUsed(sortType: NodeSortTypes = NodeSortTypes.Penalties): NodeStructure {
+    public getLeastUsed(sortType: NodeSortFilter = NodeSortTypes.Penalties): NodeStructure {
         const nodes: NodeStructure[] = this.nodes.filter((node): boolean => node.state === State.Connected);
         if (!nodes.length) throw new NodeManagerError("No connected nodes available.");
+
+        if (typeof sortType === "function") return nodes.reduce((a, b): NodeStructure => (sortType(a) < sortType(b) ? a : b));
 
         const sortFilters: Record<NodeSortTypes, SortFunction> = {
             [NodeSortTypes.Players]: (node): number => node.stats?.players ?? 0,

--- a/src/classes/node/Node.ts
+++ b/src/classes/node/Node.ts
@@ -121,12 +121,6 @@ export class Node {
     public heartbeatInterval: NodeJS.Timeout | null = null;
 
     /**
-     * Timeout handle for the stats watchdog.
-     * @type {NodeJS.Timeout | null}
-     */
-    public statsTimeout: NodeJS.Timeout | null = null;
-
-    /**
      * Whether the socket responded to the last ping. Set to false when a ping
      * is sent, back to true when a pong arrives. If still false at the next
      * ping, the socket is terminated.
@@ -176,7 +170,6 @@ export class Node {
 
         const heartbeat: Required<NodeHeartbeatOptions> = {
             interval: nodeHeartbeat.interval ?? managerHeartbeat.interval,
-            statsTimeout: nodeHeartbeat.statsTimeout ?? managerHeartbeat.statsTimeout,
         };
 
         this.options = {

--- a/src/classes/node/Rest.ts
+++ b/src/classes/node/Rest.ts
@@ -17,7 +17,7 @@ import {
 } from "../../types/Rest";
 import type { NodeStructure } from "../../types/Structures";
 import { HoshimiAgent } from "../../util/constants";
-import { stringify, updatePlayerState } from "../../util/functions/utils";
+import { censor, stringify, updatePlayerState } from "../../util/functions/utils";
 import { RestError } from "../Errors";
 
 /**
@@ -142,7 +142,7 @@ export class Rest {
 
         this.node.nodeManager.manager.debug(
             DebugLevels.Rest,
-            `[Rest] -> [${this.node.id} : ${options.method}]: Url: ${this.restUrl} | Endpoint: ${options.endpoint} | Params: ${url.search} | Body: ${options.body ? stringify(options.body) : "None"} | Headers: ${stringify(headers)}`,
+            `[Rest] -> [${this.node.id} : ${options.method}]: Url: ${this.restUrl} | Endpoint: ${options.endpoint} | Params: ${url.search} | Body: ${options.body ? stringify(options.body) : "None"} | Headers: ${stringify(censor({ data: headers, keys: ["Authorization"] }))}`,
         );
 
         const response = await fetch(url.toString(), fetchOptions).finally((): void => clearTimeout(timeout));

--- a/src/classes/player/Player.ts
+++ b/src/classes/player/Player.ts
@@ -441,7 +441,16 @@ export class Player {
             await this.queue.splice(0, to - 1);
         }
 
-        if (!this.isPlaying() && !this.queue.current) return this.play();
+        if (!this.isPlaying() && !this.queue.current) {
+            // Reachable only with `throwError: false` (an empty queue already threw above). Playing
+            // here would hand `play()` a null track and surface a ResolveError the caller opted out of.
+            if (this.queue.isEmpty()) {
+                this.manager.debug(DebugLevels.Player, `[Player] -> [Skip] Nothing left to play for guild: ${this.guildId}`);
+                return;
+            }
+
+            return this.play();
+        }
 
         this.manager.debug(DebugLevels.Player, `[Player] -> [Skip] Skipping to next track for guild: ${this.guildId}`);
 
@@ -502,9 +511,9 @@ export class Player {
 
         if (this.queue.current || this.queue.size) {
             const sources: SourceName[] = [this.queue.current, ...this.queue.tracks]
-                .filter((t): t is TrackResolvableStructure => t != null || typeof t !== "undefined")
+                .filter((t) => !!t)
                 .map((t): SourceName | undefined => t.info.sourceName)
-                .filter((s): s is SourceName => s != null || typeof s !== "undefined");
+                .filter((s) => !!s);
 
             const missings: SourceName[] = [...new Set(sources)].filter((s): boolean => !target.info!.sourceManagers.includes(s));
             if (missings.length) throw new PlayerError(`Target node is missing source managers for: ${missings.join(", ")}`);

--- a/src/classes/player/filters/DSPXPlugin.ts
+++ b/src/classes/player/filters/DSPXPlugin.ts
@@ -5,7 +5,7 @@ import { DefaultFilterPreset } from "../../../util/constants";
 /**
  * Thin facade over the `lavadspx-plugin` filters.
  *
- * Each setter delegates to {@link FilterManager.apply}; validation, envelope routing,
+ * Each setter delegates to {@link FilterManager.set}; validation, envelope routing,
  * and node-capability checks are handled by the {@link FilterRegistry}.
  *
  * @class DSPXPluginFilter
@@ -37,7 +37,7 @@ export class DSPXPluginFilter {
     public async setLowPass(
         settings: Partial<FilterPluginPassSettings> = DefaultFilterPreset.DSPXLowPass,
     ): Promise<FilterManagerStructure> {
-        return this.manager.apply<FilterPluginPassSettings>(FilterType.DSPXLowpass, {
+        return this.manager.set(FilterType.DSPXLowpass, {
             boostFactor: settings.boostFactor ?? 0,
             cutoffFrequency: settings.cutoffFrequency ?? 0,
         });
@@ -49,7 +49,7 @@ export class DSPXPluginFilter {
     public async setHighPass(
         settings: Partial<FilterPluginPassSettings> = DefaultFilterPreset.DSPXHighPass,
     ): Promise<FilterManagerStructure> {
-        return this.manager.apply<FilterPluginPassSettings>(FilterType.DSPXHighpass, {
+        return this.manager.set(FilterType.DSPXHighpass, {
             boostFactor: settings.boostFactor ?? 0,
             cutoffFrequency: settings.cutoffFrequency ?? 0,
         });
@@ -61,13 +61,13 @@ export class DSPXPluginFilter {
     public async setNormalization(
         settings: Partial<NormalizationSettings> = DefaultFilterPreset.DSPXNormalization,
     ): Promise<FilterManagerStructure> {
-        return this.manager.apply<NormalizationSettings>(FilterType.DSPXNormalization, { ...settings } as NormalizationSettings);
+        return this.manager.set(FilterType.DSPXNormalization, { ...settings } as NormalizationSettings);
     }
 
     /**
      * Set the DSPX echo filter (idempotent).
      */
     public async setEcho(settings: Partial<EchoSettings> = DefaultFilterPreset.DSPXEcho): Promise<FilterManagerStructure> {
-        return this.manager.apply<EchoSettings>(FilterType.DSPXEcho, { ...settings } as EchoSettings);
+        return this.manager.set(FilterType.DSPXEcho, { ...settings } as EchoSettings);
     }
 }

--- a/src/classes/player/filters/LavalinkPlugin.ts
+++ b/src/classes/player/filters/LavalinkPlugin.ts
@@ -8,7 +8,7 @@ type NonLengthEchoSettings = Omit<EchoSettings, "echoLength">;
 /**
  * Thin facade over the `lavalink-filter-plugin` filters.
  *
- * Each setter delegates to {@link FilterManager.apply}; validation, envelope routing,
+ * Each setter delegates to {@link FilterManager.set}; validation, envelope routing,
  * and node-capability checks are handled by the {@link FilterRegistry}.
  *
  * @class LavalinkPluginFilter
@@ -42,7 +42,7 @@ export class LavalinkPluginFilter {
      * ```
      */
     public async setEcho(settings: Partial<NonLengthEchoSettings> = DefaultFilterPreset.PluginEcho): Promise<FilterManagerStructure> {
-        return this.manager.apply<NonLengthEchoSettings>(FilterType.Echo, {
+        return this.manager.set(FilterType.Echo, {
             decay: settings.decay ?? 0,
             delay: settings.delay ?? 0,
         });
@@ -62,7 +62,7 @@ export class LavalinkPluginFilter {
     public async setReverb(
         settings: Partial<LavalinkFilterPluginReverbSettings> = DefaultFilterPreset.PluginReverb,
     ): Promise<FilterManagerStructure> {
-        return this.manager.apply<LavalinkFilterPluginReverbSettings>(FilterType.Reverb, {
+        return this.manager.set(FilterType.Reverb, {
             delays: settings.delays ?? [],
             gains: settings.gains ?? [],
         });

--- a/src/classes/player/filters/Manager.ts
+++ b/src/classes/player/filters/Manager.ts
@@ -1,4 +1,4 @@
-import { FilterRegistry, type RegistryFilterName } from "../../../registry/FiltersRegistry";
+import { type FilterRegistration, FilterRegistry, type PayloadOf, type RegistryFilterName } from "../../../registry/FiltersRegistry";
 import {
     AudioOutput,
     type ChannelMixSettings,
@@ -8,12 +8,13 @@ import {
     FilterType,
     type KaraokeSettings,
     type LowPassSettings,
+    type SetFilterOptions,
     type TimescaleSettings,
     type TremoloSettings,
 } from "../../../types/Filters";
 import type { RestOrArray } from "../../../types/Manager";
 import type { PlayerStructure } from "../../../types/Structures";
-import { AudioOutputData, DefaultFilterPreset, DefaultPlayerFilters } from "../../../util/constants";
+import { AudioOutputData, DefaultFilterPreset } from "../../../util/constants";
 import { FilterPayload } from "../../../util/functions/filters";
 import { PlayerError } from "../../Errors";
 import { DSPXPluginFilter } from "./DSPXPlugin";
@@ -22,14 +23,16 @@ import { LavalinkPluginFilter } from "./LavalinkPlugin";
 /**
  * Class representing a filter manager for a player.
  *
- * Backed by the {@link FilterRegistry}: filter writes and lookups go through the registry,
- * which knows the canonical name, scope (Core/Plugin/Vendor), payload envelope, and default-state predicate.
+ * A filter is active when its key is present in the payload, and inactive when it is absent: there is
+ * no neutral "off" payload. {@link FilterManager.set} writes a key, {@link FilterManager.clear} removes
+ * it, and {@link FilterManager.isEnabled} is presence.
  *
- * The previous `filters: EnabledPlayerFilters` toggle object has been removed; every "is X active"
- * question is derived on-demand from {@link FilterRegistry.isDefault} against the current payload.
+ * {@link FilterRegistry} routes the filters it knows to their envelope (top level, flat `pluginFilters`,
+ * or nested under a plugin) and validates them against the node. Filters it does not know can still be
+ * set: their envelope comes from {@link SetFilterOptions} instead, so no registration is required.
  *
- * The commit/envelope internals live in {@link FilterPayload} (util/functions/filters) as `this`-helpers
- * invoked with `.call(this)`, rather than private members, matching the project convention.
+ * The commit/envelope internals live in {@link FilterPayload} (util/functions/filters), which takes the
+ * manager as an argument rather than through `this` — no private members, matching the project convention.
  *
  * @class FilterManager
  */
@@ -50,11 +53,12 @@ export class FilterManager {
     public readonly bands: EQBandSettings[] = [];
 
     /**
-     * The current filter payload (wire-bound). Mutated by {@link apply} and {@link clear}.
+     * The current filter payload (wire-bound). Starts empty: a key is only present while its filter is
+     * active. Mutated by {@link FilterManager.set} and {@link FilterManager.clear}.
      * @type {FilterSettings}
      * @public
      */
-    public data: FilterSettings = structuredClone(DefaultPlayerFilters);
+    public data: FilterSettings = {};
 
     /**
      * Thin facade for filters provided by the `lavalink-filter-plugin`.
@@ -81,8 +85,49 @@ export class FilterManager {
     }
 
     // ============================================================
-    // Generic registry-driven API
+    // Generic API
     // ============================================================
+
+    /**
+     * Set a filter to `payload` and commit.
+     *
+     * Any filter can be set, registered or not: {@link SetFilterOptions} decides the envelope when the
+     * registry does not know the name (or when you want to override what it resolved). Idempotent —
+     * calling repeatedly with the same payload yields the same wire state.
+     * The payload is checked against {@link FilterPayloads} for the built-ins and against
+     * {@link CustomizableFilters} for anything you declared; a name neither knows takes `unknown`.
+     * @param {RegistryFilterName} name The filter name (or alias) to set.
+     * @param {PayloadOf<K>} payload The payload to write.
+     * @param {SetFilterOptions} [options={}] Envelope and validation options.
+     * @returns {Promise<this>} A promise that resolves to the filter manager.
+     * @throws {PlayerError} If `plugin` and `top` are combined, or if validation was requested for a
+     * filter the node does not advertise.
+     * @throws {NodeError} If a registered filter is not supported by the node (unless `validate: false`).
+     * @example
+     * ```ts
+     * await player.filterManager.set(FilterType.Echo, { decay: 0.5, delay: 200 }); // registry routes it
+     * await player.filterManager.set("myFilter", { gain: 2 });                     // pluginFilters.myFilter
+     * await player.filterManager.set("boost", { gain: 2 }, { plugin: "my-plugin" }); // nested
+     * await player.filterManager.set("forkEcho", { decay: 0.5 }, { top: true });   // top level
+     * ```
+     */
+    public async set<K extends RegistryFilterName>(name: K, payload: PayloadOf<K>, options: SetFilterOptions = {}): Promise<this> {
+        const routed: boolean = typeof options.plugin !== "undefined" || options.top === true;
+        const registration: FilterRegistration | null = FilterRegistry.resolve(name, this.player.node);
+
+        // Registered filters are validated by default; an explicit envelope or an unknown name is taken
+        // at face value, since the registry has nothing to say about either.
+        if (options.validate ?? (!routed && registration !== null)) {
+            if (registration) FilterRegistry.validate({ node: this.player.node, name });
+            else if (!this.player.node.info?.filters?.some((filter): boolean => filter === String(name)))
+                throw new PlayerError(`The node ${this.player.node.id} does not advertise the filter '${String(name)}'.`);
+        }
+
+        FilterPayload.write(this, FilterPayload.route(this, name, options), payload);
+        await FilterPayload.commit(this);
+
+        return this;
+    }
 
     /**
      * Commit the current filter payload to the node.
@@ -90,60 +135,74 @@ export class FilterManager {
      */
     public apply(): Promise<this>;
     /**
-     * Set the given filter to `payload` and commit. Idempotent — calling repeatedly
-     * with the same payload yields the same wire state.
+     * Set the given filter to `payload` and commit.
+     * @deprecated Use {@link FilterManager.set} instead, which also takes {@link SetFilterOptions}.
      * @param {RegistryFilterName} name The canonical filter name (or alias) to set.
-     * @param {TPayload} payload The payload to write into the envelope chosen by the registry.
+     * @param {PayloadOf<K>} payload The payload to write into the envelope chosen by the registry.
      * @returns {Promise<this>} A promise that resolves to the filter manager.
-     * @throws {Error} If the filter is not registered, or if the node does not advertise the filter / required plugin.
-     * @example
-     * ```ts
-     * await player.filterManager.apply(FilterType.Echo, { decay: 0.5, delay: 200 });
-     * ```
      */
-    public apply<TPayload>(name: RegistryFilterName, payload: TPayload): Promise<this>;
-    public async apply<TPayload>(name?: RegistryFilterName, payload?: TPayload): Promise<this> {
-        if (typeof name !== "undefined") {
-            FilterRegistry.validate({ node: this.player.node, name });
-            const entry = FilterRegistry.resolve(name, this.player.node);
-            if (!entry) throw new PlayerError(`No registered filter resolves '${String(name)}'.`);
-            FilterPayload.writeToEnvelope.call(this, entry, payload);
-        }
-        await FilterPayload.commit.call(this);
+    public apply<K extends RegistryFilterName>(name: K, payload: PayloadOf<K>): Promise<this>;
+    public async apply(name?: RegistryFilterName, payload?: unknown): Promise<this> {
+        if (typeof name !== "undefined") return this.set(name, payload as PayloadOf<RegistryFilterName>);
+
+        await FilterPayload.commit(this);
         return this;
     }
 
     /**
      * Remove the given filter from the payload and commit.
-     * @param {RegistryFilterName} name The canonical filter name (or alias) to clear.
+     *
+     * Pass the same {@link SetFilterOptions} routing used to set it, so an unregistered filter is cleared
+     * from the envelope it was written to.
+     * @param {RegistryFilterName} name The filter name (or alias) to clear.
+     * @param {SetFilterOptions} [options={}] The routing options used when it was set.
      * @returns {Promise<this>} A promise that resolves to the filter manager.
      * @example
      * ```ts
      * await player.filterManager.clear(FilterType.Karaoke);
+     * await player.filterManager.clear("boost", { plugin: "my-plugin" });
      * ```
      */
-    public async clear(name: RegistryFilterName): Promise<this> {
-        const entry = FilterRegistry.resolve(name, this.player.node);
-        if (entry) FilterPayload.clearFromEnvelope.call(this, entry);
-        await FilterPayload.commit.call(this);
+    public async clear(name: RegistryFilterName, options: SetFilterOptions = {}): Promise<this> {
+        FilterPayload.clear(this, FilterPayload.route(this, name, options));
+        await FilterPayload.commit(this);
+
         return this;
     }
 
     /**
-     * Whether the given filter is currently active (its payload is not the default/off state).
-     * @param {RegistryFilterName} name The canonical filter name (or alias).
-     * @returns {boolean} True if the filter has a non-default payload, false otherwise.
+     * Read the payload a filter is currently set to.
+     *
+     * Typed the same way {@link FilterManager.set} is, so there is no need to reach into
+     * {@link FilterManager.data} and narrow by hand.
+     * @param {RegistryFilterName} name The filter name (or alias).
+     * @param {SetFilterOptions} [options={}] The routing options used when it was set.
+     * @returns {PayloadOf<K> | undefined} The payload, or `undefined` when the filter is not active.
+     * @example
+     * ```ts
+     * const timescale = player.filterManager.get(FilterType.Timescale); // TimescaleSettings | undefined
+     * const boost = player.filterManager.get("boost", { plugin: "my-plugin" });
+     * ```
      */
-    public isEnabled(name: RegistryFilterName): boolean {
-        const entry = FilterRegistry.resolve(name, this.player.node);
-        if (!entry) return false;
-        const payload = FilterPayload.readFromEnvelope.call(this, entry);
-        return !FilterRegistry.isDefault(name, payload);
+    public get<K extends RegistryFilterName>(name: K, options: SetFilterOptions = {}): PayloadOf<K> | undefined {
+        return FilterPayload.read(this, FilterPayload.route(this, name, options)) as PayloadOf<K> | undefined;
+    }
+
+    /**
+     * Whether the given filter is currently active, i.e. whether its key is present in the payload.
+     * @param {RegistryFilterName} name The filter name (or alias).
+     * @param {SetFilterOptions} [options={}] The routing options used when it was set.
+     * @returns {boolean} True if the filter has a payload, false otherwise.
+     */
+    public isEnabled(name: RegistryFilterName, options: SetFilterOptions = {}): boolean {
+        return typeof this.get(name, options) !== "undefined";
     }
 
     /**
      * Returns every active filter name as derived from the current payload.
-     * @returns {string[]} Canonical filter names whose payload is non-default.
+     *
+     * Only covers registered filters; keys written for unregistered ones are not listed.
+     * @returns {string[]} Canonical filter names present in the payload.
      */
     public getEnabled(): string[] {
         return FilterRegistry.getFilters().filter((name): boolean => this.isEnabled(name));
@@ -152,20 +211,21 @@ export class FilterManager {
     /**
      * Backward-compatible alias for {@link isEnabled}.
      * @param {RegistryFilterName} filter The filter to check.
+     * @param {SetFilterOptions} [options={}] The routing options used when it was set.
      * @returns {boolean} True if active.
      */
-    public has(filter: RegistryFilterName): boolean {
-        return this.isEnabled(filter);
+    public has(filter: RegistryFilterName, options: SetFilterOptions = {}): boolean {
+        return this.isEnabled(filter, options);
     }
 
     /**
-     * Reset every filter to its default state and commit.
+     * Drop every filter and commit an empty payload.
      * @returns {Promise<this>} A promise that resolves to the filter manager.
      */
     public async reset(): Promise<this> {
         this.bands.length = 0;
-        this.data = structuredClone(DefaultPlayerFilters);
-        await FilterPayload.commit.call(this);
+        this.data = {};
+        await FilterPayload.commit(this);
         return this;
     }
 
@@ -178,7 +238,7 @@ export class FilterManager {
     }
 
     // ============================================================
-    // Typed convenience setters (idempotent — delegate to apply)
+    // Typed convenience setters (idempotent — delegate to set)
     // ============================================================
 
     /**
@@ -188,7 +248,7 @@ export class FilterManager {
     public async setVolume(volume: number): Promise<this> {
         if (typeof volume !== "number" || Number.isNaN(volume) || volume < 0 || volume > 5)
             throw new PlayerError("Volume must be a number between 0 and 5.");
-        return this.apply<number>(FilterType.Volume, volume);
+        return this.set(FilterType.Volume, volume);
     }
 
     /**
@@ -200,7 +260,7 @@ export class FilterManager {
             throw new PlayerError("Bands must be a non-empty object array containing 'band' and 'gain' properties.");
         for (const { band, gain } of list) this.bands[band] = { band, gain };
         this.data.equalizer = [...this.bands];
-        await FilterPayload.commit.call(this);
+        await FilterPayload.commit(this);
         return this;
     }
 
@@ -209,8 +269,8 @@ export class FilterManager {
      */
     public async clearEQBands(): Promise<this> {
         this.bands.length = 0;
-        this.data.equalizer = [];
-        await FilterPayload.commit.call(this);
+        delete this.data.equalizer;
+        await FilterPayload.commit(this);
         return this;
     }
 
@@ -218,7 +278,7 @@ export class FilterManager {
      * Set the karaoke filter.
      */
     public async setKaraoke(settings: Partial<KaraokeSettings> = DefaultFilterPreset.Karaoke): Promise<this> {
-        return this.apply<KaraokeSettings>(FilterType.Karaoke, {
+        return this.set(FilterType.Karaoke, {
             level: settings.level ?? 0,
             monoLevel: settings.monoLevel ?? 0,
             filterBand: settings.filterBand ?? 0,
@@ -230,7 +290,7 @@ export class FilterManager {
      * Set the tremolo filter.
      */
     public async setTremolo(settings: Partial<TremoloSettings> = DefaultFilterPreset.Tremolo): Promise<this> {
-        return this.apply<TremoloSettings>(FilterType.Tremolo, {
+        return this.set(FilterType.Tremolo, {
             frequency: settings.frequency ?? 0,
             depth: settings.depth ?? 0,
         });
@@ -240,7 +300,7 @@ export class FilterManager {
      * Set the vibrato filter.
      */
     public async setVibrato(settings: Partial<TremoloSettings> = DefaultFilterPreset.Vibrato): Promise<this> {
-        return this.apply<TremoloSettings>(FilterType.Vibrato, {
+        return this.set(FilterType.Vibrato, {
             frequency: settings.frequency ?? 0,
             depth: settings.depth ?? 0,
         });
@@ -250,21 +310,21 @@ export class FilterManager {
      * Set the low-pass filter.
      */
     public async setLowPass(settings: Partial<LowPassSettings> = DefaultFilterPreset.Lowpass): Promise<this> {
-        return this.apply<LowPassSettings>(FilterType.LowPass, { smoothing: settings.smoothing ?? 0 });
+        return this.set(FilterType.LowPass, { smoothing: settings.smoothing ?? 0 });
     }
 
     /**
      * Set the distortion filter.
      */
     public async setDistortion(settings: Partial<DistortionSettings> = DefaultFilterPreset.Distortion): Promise<this> {
-        return this.apply<DistortionSettings>(FilterType.Distortion, { ...settings });
+        return this.set(FilterType.Distortion, { ...settings });
     }
 
     /**
      * Set the timescale filter explicitly.
      */
     public async setTimescale(settings: Partial<TimescaleSettings>): Promise<this> {
-        return this.apply<TimescaleSettings>(FilterType.Timescale, {
+        return this.set(FilterType.Timescale, {
             speed: settings.speed ?? 1,
             pitch: settings.pitch ?? 1,
             rate: settings.rate ?? 1,
@@ -276,7 +336,7 @@ export class FilterManager {
      */
     public async setSpeed(speed: number = 1): Promise<this> {
         const current: TimescaleSettings = this.data.timescale ?? { speed: 1, pitch: 1, rate: 1 };
-        return this.apply<TimescaleSettings>(FilterType.Timescale, { ...current, speed });
+        return this.set(FilterType.Timescale, { ...current, speed });
     }
 
     /**
@@ -284,7 +344,7 @@ export class FilterManager {
      */
     public async setRate(rate: number = 1): Promise<this> {
         const current: TimescaleSettings = this.data.timescale ?? { speed: 1, pitch: 1, rate: 1 };
-        return this.apply<TimescaleSettings>(FilterType.Timescale, { ...current, rate });
+        return this.set(FilterType.Timescale, { ...current, rate });
     }
 
     /**
@@ -292,14 +352,14 @@ export class FilterManager {
      */
     public async setPitch(pitch: number = 1): Promise<this> {
         const current: TimescaleSettings = this.data.timescale ?? { speed: 1, pitch: 1, rate: 1 };
-        return this.apply<TimescaleSettings>(FilterType.Timescale, { ...current, pitch });
+        return this.set(FilterType.Timescale, { ...current, pitch });
     }
 
     /**
      * Apply the Nightcore preset to the timescale filter.
      */
     public async setNightcore(settings: Partial<TimescaleSettings> = DefaultFilterPreset.Nightcore): Promise<this> {
-        return this.apply<TimescaleSettings>(FilterType.Timescale, {
+        return this.set(FilterType.Timescale, {
             speed: settings.speed ?? DefaultFilterPreset.Nightcore.speed,
             pitch: settings.pitch ?? DefaultFilterPreset.Nightcore.pitch,
             rate: settings.rate ?? DefaultFilterPreset.Nightcore.rate,
@@ -310,7 +370,7 @@ export class FilterManager {
      * Apply the Vaporwave preset to the timescale filter.
      */
     public async setVaporwave(settings: Partial<TimescaleSettings> = DefaultFilterPreset.Vaporwave): Promise<this> {
-        return this.apply<TimescaleSettings>(FilterType.Timescale, {
+        return this.set(FilterType.Timescale, {
             speed: settings.speed ?? DefaultFilterPreset.Vaporwave.speed,
             pitch: settings.pitch ?? DefaultFilterPreset.Vaporwave.pitch,
             rate: settings.rate ?? DefaultFilterPreset.Vaporwave.rate,
@@ -349,7 +409,7 @@ export class FilterManager {
     public async setAudioOutput(output: AudioOutput): Promise<this> {
         const outputs: AudioOutput[] = Object.values(AudioOutput);
         if (!outputs.includes(output)) throw new PlayerError(`Audio output must be one of: ${outputs.join(", ")}.`);
-        return this.apply<ChannelMixSettings>(FilterType.ChannelMix, { ...AudioOutputData[output] });
+        return this.set(FilterType.ChannelMix, { ...AudioOutputData[output] });
     }
 
     /**

--- a/src/classes/queue/Queue.ts
+++ b/src/classes/queue/Queue.ts
@@ -348,8 +348,15 @@ export class Queue {
         const index: number = this.tracks.indexOf(track);
         if (index === -1) return this;
 
-        await this.splice(index, 1);
-        await this.add(track, to - 1);
+        // Moved in place rather than through splice()/add(): each of those emits and persists on its
+        // own, so a single move used to cost three storage writes and three queueUpdate events.
+        this.tracks.splice(index, 1);
+
+        // `to` is a 0-based index into the queue without the moved track; clamped so an out of range
+        // position lands at the start or the end of the queue.
+        const position: number = Math.max(0, Math.min(to, this.tracks.length));
+
+        this.tracks.splice(position, 0, track);
 
         this.player.manager.emit(EventNames.QueueUpdate, this.player, this);
         this.player.manager.debug(DebugLevels.Queue, `[Queue] -> [Move] Moved track ${track.info.title} to position ${to}.`);
@@ -383,8 +390,9 @@ export class Queue {
         deleteCount: number,
         tracks: TrackResolvableStructure | TrackResolvableStructure[] = [],
     ): Promise<TrackResolvableStructure[]> {
-        if (!this.size && tracks) await this.add(tracks);
-
+        // No empty-queue special case: `Array.prototype.splice` inserts into an empty array just fine.
+        // Routing through add() first appended the tracks and then inserted them again (duplicating
+        // every one of them), and did so even for the default empty `tracks`.
         const spliced: TrackResolvableStructure[] = this.tracks.splice(start, deleteCount, ...flatten(tracks));
 
         this.player.manager.emit(EventNames.QueueUpdate, this.player, this);
@@ -411,16 +419,17 @@ export class Queue {
         const tracks: TrackResolvableStructure[] = [...this.tracks, ...this.history, this.current].filter(
             (track): track is TrackResolvableStructure => !!track,
         );
-        if (tracks.length && tracks.every((track): boolean => !(track instanceof Track) && !(track instanceof UnresolvedTrack)))
+        if (tracks.some((track): boolean => !(track instanceof Track) && !(track instanceof UnresolvedTrack)))
             throw new QueueError("Cannot convert queue to JSON because it contains invalid object tracks.");
 
         const max: number = this.player.manager.options.queueOptions.maxHistory;
 
-        if (this.history.length > max) this.history.splice(max, this.history.length);
+        // Trim on a copy: serialising must not mutate the live queue.
+        const history: TrackStructure[] = this.history.slice(0, max);
 
         return {
             tracks: this.tracks.map((track): TrackJSON => track.toJSON()),
-            history: this.history.map((track): TrackJSON => track.toJSON()),
+            history: history.map((track): TrackJSON => track.toJSON()),
             current: this.current?.toJSON() ?? null,
         };
     }

--- a/src/classes/queue/Utils.ts
+++ b/src/classes/queue/Utils.ts
@@ -93,7 +93,7 @@ export class QueueUtils {
      */
     public save(): Awaitable<void> {
         const max: number = this.options.maxHistory;
-        const length: number = this.queue.tracks.length;
+        const length: number = this.queue.history.length;
 
         if (length > max) this.queue.history.splice(0, length - max);
 

--- a/src/classes/storage/PlayerMemory.ts
+++ b/src/classes/storage/PlayerMemory.ts
@@ -42,7 +42,9 @@ export class PlayerMemoryStorage<
     }
 
     public values<K extends StorageKeys[], V extends StorageValues<K[number]>>(): Awaitable<V[]> {
-        return [...this.internal.values()] as never as V[];
+        return [...this.internal.entries()]
+            .filter(([key]): boolean => !this.isInternal(this.strip(key as string)))
+            .map(([, value]) => value) as never as V[];
     }
 
     public entries<K extends StorageKeys[], V extends StorageValues<K[number]>>(): Awaitable<[K, V][]> {

--- a/src/classes/storage/QueueMemory.ts
+++ b/src/classes/storage/QueueMemory.ts
@@ -17,7 +17,10 @@ export class QueueMemoryStorage<T extends QueueJSON = QueueJSON> extends QueueSt
     private readonly storage: Map<string, QueueJSON> = new Map();
 
     public get(key: string): T | undefined {
-        return this.parse(this.storage.get(key));
+        const value: QueueJSON | undefined = this.storage.get(this.buildKey(this.namespace, key));
+        if (typeof value === "undefined") return undefined;
+
+        return this.parse(value);
     }
 
     public set(key: string, value: T): void {

--- a/src/registry/FiltersRegistry.ts
+++ b/src/registry/FiltersRegistry.ts
@@ -1,6 +1,6 @@
 import { NodeError } from "../classes/Errors";
 import type { Node } from "../classes/node/Node";
-import { FilterType } from "../types/Filters";
+import { type FilterPayloads, FilterType } from "../types/Filters";
 import { DebugLevels, EventNames, type Hint, type RestOrArray } from "../types/Manager";
 import { PluginNames } from "../types/Node";
 import { normalize, toArray } from "../util/functions/utils";
@@ -11,7 +11,8 @@ import { PluginCapabilities, PluginRegistry, type RegistryCapability, type Regis
  */
 export enum FilterScope {
     /**
-     * Built-in Lavalink filter. Lives at the top level of the `filters` payload.
+     * Filter that lives at the top level of the `filters` payload: the Lavalink built-ins, and anything a
+     * fork exposes alongside them.
      */
     Core = "core",
     /**
@@ -20,41 +21,26 @@ export enum FilterScope {
      * When `pluginName` is omitted the filter is placed flat at `pluginFilters[name]` (legacy convention used by lavadspx-plugin and similar).
      */
     Plugin = "plugin",
-    /**
-     * Filter exclusive to a Lavalink fork (e.g. Nodelink). Lives at the top level of `filters` but only applies on the matching fork.
-     */
-    Vendor = "vendor",
 }
 
 /**
- * Custom filter names for Hoshimi.
+ * Custom filters for Hoshimi: the key is the filter name, the value is the payload it takes.
  *
- * Extend this interface via module augmentation to provide custom filter names with autocompletion.
+ * Extend this interface via module augmentation to get autocompletion for the name and a checked payload
+ * in `FilterManager.set` / `FilterManager.get`. Registering the filter is a separate, optional step that
+ * buys envelope routing and node validation; this only adds types.
  * @example
  * ```ts
  * declare module "hoshimi" {
  *   interface CustomizableFilters {
- *     forkEcho: "fork-echo";
+ *     forkEcho: { decay: number; delay: number };
  *   }
  * }
+ *
+ * await player.filterManager.set("forkEcho", { decay: 0.5, delay: 200 }, { top: true });
  * ```
  */
 export interface CustomizableFilters {}
-
-/**
- * Custom vendor (fork) identifiers for Hoshimi.
- *
- * Extend this interface via module augmentation to provide custom vendor identifiers with autocompletion.
- * @example
- * ```ts
- * declare module "hoshimi" {
- *   interface CustomizableVendors {
- *     myFork: "my-fork";
- *   }
- * }
- * ```
- */
-export interface CustomizableVendors {}
 
 /**
  * The custom filter name keys provided by users via module augmentation.
@@ -62,24 +48,24 @@ export interface CustomizableVendors {}
 export type FilterNameKey = keyof CustomizableFilters;
 
 /**
- * The custom vendor name keys provided by users via module augmentation.
- */
-export type VendorNameKey = keyof CustomizableVendors;
-
-/**
  * The full filter name accepted by the filter registry.
  */
 export type RegistryFilterName = FilterType | Hint<FilterNameKey>;
 
 /**
- * The vendor identifier accepted by the filter registry.
+ * The payload a filter takes: whatever {@link CustomizableFilters} declares for it, else the built-in
+ * shape from {@link FilterPayloads}, else `unknown` — so a filter nobody declared accepts any payload.
  */
-export type RegistryVendorName = "nodelink" | Hint<VendorNameKey>;
+export type PayloadOf<K> = K extends keyof CustomizableFilters
+    ? CustomizableFilters[K]
+    : K extends keyof FilterPayloads
+      ? FilterPayloads[K]
+      : unknown;
 
 /**
  * Registration options for a filter.
  */
-export interface FilterRegistration<TPayload = unknown> {
+export interface FilterRegistration {
     /**
      * The canonical filter name. Used as the registry identity/index key.
      * Unless {@link FilterRegistration.wireName} is set, it is also the key written into the wire payload.
@@ -112,24 +98,19 @@ export interface FilterRegistration<TPayload = unknown> {
      */
     capability?: RegistryCapability;
     /**
-     * Forks that implement this filter — required when `scope === FilterScope.Vendor`.
-     */
-    vendors?: RegistryVendorName[];
-    /**
      * Alternative names that should resolve to this same filter (e.g. fork renames sharing the same payload shape).
      * Aliases that collide with an already-registered canonical name are ignored to avoid hijacking.
      */
     aliases?: string[];
-    /**
-     * Predicate that returns `true` when the given payload represents the "off" state.
-     * Used by the filter manager to derive `isEnabled(name)` and to short-circuit no-op writes.
-     */
-    isDefault?: (payload: TPayload) => boolean;
-    /**
-     * The payload written when the filter is reset/cleared. If omitted, the manager will simply remove the key.
-     */
-    defaultPayload?: TPayload;
 }
+
+/**
+ * The envelope coordinates of a filter: everything needed to place its payload on the wire.
+ *
+ * A {@link FilterRegistration} satisfies it, and so does a synthetic route built on the fly for a
+ * filter that was never registered (see `FilterManager.set`).
+ */
+export type FilterRoute = Pick<FilterRegistration, "name" | "wireName" | "scope" | "pluginName">;
 
 /**
  * Options for validating that a node can host a registered filter.
@@ -206,14 +187,6 @@ function pickByNodeContext(candidates: CanonicalEntry[], node: Node): CanonicalE
 
     const installedPlugins = node.info?.plugins ?? [];
 
-    if (node.isNodelink()) {
-        const vendor: CanonicalEntry | undefined = candidates.find(
-            (entry): boolean =>
-                entry.scope === FilterScope.Vendor && (entry.vendors?.some((v): boolean => normalize(String(v)) === "nodelink") ?? false),
-        );
-        if (vendor) return vendor;
-    }
-
     const core: CanonicalEntry | undefined = candidates.find((entry): boolean => entry.scope === FilterScope.Core);
     if (core) return core;
 
@@ -229,25 +202,15 @@ function pickByNodeContext(candidates: CanonicalEntry[], node: Node): CanonicalE
 }
 
 /**
- * Identity helper that preserves the inferred `TPayload` of a single filter registration.
+ * Identity helper for a single filter registration.
  *
- * Use inside `FilterRegistry.register([ ... ])` so each element keeps its own typed
- * `isDefault` and `defaultPayload` instead of collapsing to `FilterRegistration<unknown>`
- * (which happens because function parameters are contravariant under `strictFunctionTypes`).
- *
- * @example
- * ```ts
- * FilterRegistry.register([
- *   defineFilter({
- *     name: "boost",
- *     scope: FilterScope.Plugin,
- *     defaultPayload: { gain: 0 },
- *     isDefault: (p) => p.gain === 0, // p: { gain: number }
- *   }),
- * ]);
- * ```
+ * @deprecated Now a plain pass-through. It existed to preserve the inferred payload type of the
+ * `isDefault` predicate inside a batch registration; predicates are gone (a filter is active by the
+ * presence of its key), so registrations can be passed to {@link FilterRegistry.register} as-is.
+ * @param {FilterRegistration} registration The registration to return unchanged.
+ * @returns {FilterRegistration} The same registration.
  */
-export function defineFilter<TPayload>(registration: FilterRegistration<TPayload>): FilterRegistration<TPayload> {
+export function defineFilter(registration: FilterRegistration): FilterRegistration {
     return registration;
 }
 
@@ -258,34 +221,28 @@ export const FilterRegistry = {
     /**
      * Register one or multiple filter definitions.
      *
-     * Two call shapes:
-     * - **Single registration**: the payload type is inferred per call from `defaultPayload`
-     *   or from an annotated `isDefault` parameter — giving you typed predicates without manual `<T>`.
-     * - **Batch (rest args or single array)**: each element accepts `FilterRegistration<any>`
-     *   to bypass the contravariance of `isDefault`. For typed predicates inside a batch,
-     *   wrap each element with {@link defineFilter} — that preserves per-element inference.
+     * Registration is optional: `FilterManager.set` can write any filter, and only needs the registry to
+     * route and validate the ones it knows. Register a filter to get envelope routing by name, node
+     * validation, alias resolution and fork gating for free.
      *
+     * @param {RestOrArray<FilterRegistration>} registrations The registrations, as rest args or one array.
      * @returns {string[]} The canonical filter names that were registered (or already present).
      * @example
      * ```ts
-     * // Single — T inferred from defaultPayload
      * FilterRegistry.register({
      *   name: "boost",
      *   scope: FilterScope.Plugin,
      *   pluginName: "my-fork-plugin",
      *   capability: "fork-filters",
-     *   defaultPayload: { gain: 0 },
-     *   isDefault: (p) => p.gain === 0, // p: { gain: number }
      * });
      *
-     * // Batch — wrap each element to preserve its payload type
      * FilterRegistry.register([
-     *   defineFilter({ name: "a", scope: FilterScope.Core, isDefault: (v: number) => v === 1 }),
-     *   defineFilter({ name: "b", scope: FilterScope.Core, isDefault: (v: number) => v === 0 }),
+     *   { name: "forkEcho", scope: FilterScope.Core },
+     *   { name: "forkReverb", scope: FilterScope.Core },
      * ]);
      * ```
      */
-    register: ((...registrations: RestOrArray<FilterRegistration<any>>): string[] => {
+    register(...registrations: RestOrArray<FilterRegistration>): string[] {
         const results: string[] = [];
 
         for (const registration of toArray(registrations)) {
@@ -303,10 +260,7 @@ export const FilterRegistry = {
 
             const duplicate: boolean = existing.some(
                 (e): boolean =>
-                    e.scope === entry.scope &&
-                    normalize(String(e.pluginName ?? "")) === normalize(String(entry.pluginName ?? "")) &&
-                    (e.vendors ?? []).map((v): string => normalize(String(v))).join(",") ===
-                        (entry.vendors ?? []).map((v): string => normalize(String(v))).join(","),
+                    e.scope === entry.scope && normalize(String(e.pluginName ?? "")) === normalize(String(entry.pluginName ?? "")),
             );
             if (!duplicate) existing.push(entry);
 
@@ -321,9 +275,6 @@ export const FilterRegistry = {
         }
 
         return results;
-    }) as {
-        <TPayload = unknown>(registration: FilterRegistration<TPayload>): string[];
-        (...registrations: RestOrArray<FilterRegistration<any>>): string[];
     },
 
     /**
@@ -358,64 +309,29 @@ export const FilterRegistry = {
     },
 
     /**
-     * Get every registration for a name or alias, regardless of node context.
-     * @param {RegistryFilterName} name The filter name or alias.
-     * @returns {FilterRegistration[]} The full list of registrations.
+     * Whether the given key is the name of a plugin that owns nested filters, i.e. whether
+     * `pluginFilters[key]` is an envelope rather than a filter payload.
+     * @param {string} key The candidate `pluginFilters` key.
+     * @returns {boolean} Whether any registration nests its filters under this plugin name.
      */
-    getAll(name: RegistryFilterName): FilterRegistration[] {
-        return getEntries(String(name)).slice();
-    },
-
-    /**
-     * Whether a payload represents the default (off) state for the named filter.
-     * Returns `true` for `null`/`undefined` payloads when no `isDefault` predicate was registered.
-     * @param {RegistryFilterName} name The filter name or alias.
-     * @param {unknown} payload The payload to inspect.
-     * @returns {boolean} Whether the payload is the default/off state.
-     */
-    isDefault(name: RegistryFilterName, payload: unknown): boolean {
-        const entries: CanonicalEntry[] = getEntries(String(name));
-        // Prefer an entry that actually declares a predicate; fall back to the first entry otherwise.
-        const entry: CanonicalEntry | undefined = entries.find((e): boolean => typeof e.isDefault === "function") ?? entries[0];
-        if (!entry?.isDefault) return payload === undefined || payload === null;
-        return entry.isDefault(payload);
-    },
-
-    /**
-     * Whether the given key is the wire key of any registered filter (as opposed to a plugin-name wrapper
-     * that holds nested filters inside `pluginFilters`).
-     * @param {string} key The candidate wire key.
-     * @returns {boolean} Whether any registration writes to this wire key.
-     */
-    isWireKey(key: string): boolean {
+    isPluginName(key: string): boolean {
         const target: string = keyOf(key);
         for (const entries of entriesByName.values()) {
             for (const entry of entries) {
-                if (keyOf(String(entry.wireName ?? entry.name)) === target) return true;
+                if (entry.pluginName && keyOf(String(entry.pluginName)) === target) return true;
             }
         }
         return false;
     },
 
     /**
-     * Whether a payload written flat under `pluginFilters[wireKey]` is in its default (off) state.
-     * Resolves the flat plugin registration (scope {@link FilterScope.Plugin}, no `pluginName`) by wire key,
-     * so a filter that shares a wire key with a nested one (e.g. `echo`) is evaluated with the correct predicate.
-     * @param {string} wireKey The flat key under `pluginFilters`.
-     * @param {unknown} payload The payload to inspect.
-     * @returns {boolean} Whether the payload is the default/off state.
+     * Whether the registry knows a name at all, regardless of node context. Distinguishes "never
+     * registered" from "registered but not resolvable on this node".
+     * @param {RegistryFilterName} name The filter name (or alias).
+     * @returns {boolean} Whether any registration exists under that name.
      */
-    isDefaultFlatPlugin(wireKey: string, payload: unknown): boolean {
-        const target: string = keyOf(wireKey);
-        for (const entries of entriesByName.values()) {
-            for (const entry of entries) {
-                if (entry.scope === FilterScope.Plugin && !entry.pluginName && keyOf(String(entry.wireName ?? entry.name)) === target) {
-                    if (!entry.isDefault) return payload === undefined || payload === null;
-                    return entry.isDefault(payload);
-                }
-            }
-        }
-        return this.isDefault(wireKey, payload);
+    isKnown(name: RegistryFilterName): boolean {
+        return getEntries(String(name)).length > 0;
     },
 
     /**
@@ -446,35 +362,6 @@ export const FilterRegistry = {
      */
     getFilters(): string[] {
         return canonicalFilters.slice();
-    },
-
-    /**
-     * Returns all canonical filter names that have at least one entry of the given scope.
-     * @param {FilterScope} scope The scope to filter by.
-     * @returns {string[]} The matching canonical names.
-     */
-    getByScope(scope: FilterScope): string[] {
-        const out: string[] = [];
-        for (const name of canonicalFilters) {
-            const entries: CanonicalEntry[] = entriesByName.get(keyOf(name)) ?? [];
-            if (entries.some((e): boolean => e.scope === scope)) out.push(name);
-        }
-        return out;
-    },
-
-    /**
-     * Returns all canonical filter names provided by a specific plugin.
-     * @param {RegistryPluginName} pluginName The plugin name to filter by.
-     * @returns {string[]} The matching canonical names.
-     */
-    getByPlugin(pluginName: RegistryPluginName): string[] {
-        const target: string = normalize(String(pluginName));
-        const out: string[] = [];
-        for (const name of canonicalFilters) {
-            const entries: CanonicalEntry[] = entriesByName.get(keyOf(name)) ?? [];
-            if (entries.some((e): boolean => normalize(String(e.pluginName ?? "")) === target)) out.push(name);
-        }
-        return out;
     },
 
     /**
@@ -548,16 +435,6 @@ export const FilterRegistry = {
             });
         }
 
-        if (entry.scope === FilterScope.Vendor) {
-            if (!options.node.isNodelink()) {
-                throw new NodeError({
-                    id: options.node.id,
-                    message: `Filter '${String(entry.name)}' is vendor-scoped and node ${options.node.id} is not a recognised fork.`,
-                });
-            }
-            return;
-        }
-
         const advertised: boolean =
             info.filters?.some((f): boolean => normalize(f) === normalize(String(entry.wireName ?? entry.name))) ?? false;
 
@@ -605,140 +482,45 @@ export const FilterRegistry = {
     },
 } as const;
 
-// Pre-register built-in filters.
+// Pre-register built-in filters. Plain objects: registration only describes where a filter lives and
+// what the node must provide, since a filter is active by the presence of its key.
 FilterRegistry.register([
     // Core (Lavalink built-ins exposed in `filters.<name>`).
-    defineFilter({
-        name: FilterType.Volume,
-        scope: FilterScope.Core,
-        isDefault: (v: number): boolean => v === 1,
-    }),
-    defineFilter({
-        name: FilterType.LowPass,
-        scope: FilterScope.Core,
-        isDefault: (p: { smoothing?: number } | null | undefined): boolean => !p || (p.smoothing ?? 0) === 0,
-    }),
-    defineFilter({
-        name: FilterType.Karaoke,
-        scope: FilterScope.Core,
-        // Off when absent or every parameter is zero (the neutral payload in DefaultPlayerFilters).
-        isDefault: (p: { level?: number; monoLevel?: number; filterBand?: number; filterWidth?: number } | null | undefined): boolean =>
-            !p || ((p.level ?? 0) === 0 && (p.monoLevel ?? 0) === 0 && (p.filterBand ?? 0) === 0 && (p.filterWidth ?? 0) === 0),
-    }),
-    defineFilter({
-        name: FilterType.Rotation,
-        scope: FilterScope.Core,
-        isDefault: (p: { rotationHz?: number } | null | undefined): boolean => !p || (p.rotationHz ?? 0) === 0,
-    }),
-    defineFilter({
-        name: FilterType.Tremolo,
-        scope: FilterScope.Core,
-        isDefault: (p: { depth?: number } | null | undefined): boolean => !p || (p.depth ?? 0) === 0,
-    }),
-    defineFilter({
-        name: FilterType.Vibrato,
-        scope: FilterScope.Core,
-        isDefault: (p: { depth?: number } | null | undefined): boolean => !p || (p.depth ?? 0) === 0,
-    }),
-    defineFilter({
-        name: FilterType.Timescale,
-        scope: FilterScope.Core,
-        isDefault: (p: { speed?: number; pitch?: number; rate?: number } | null | undefined): boolean =>
-            !p || ((p.speed ?? 1) === 1 && (p.pitch ?? 1) === 1 && (p.rate ?? 1) === 1),
-    }),
-    defineFilter({
-        name: FilterType.Distortion,
-        scope: FilterScope.Core,
-        // Off when absent or the identity transform (all offsets 0 and all scales 1), matching DefaultPlayerFilters.
-        isDefault: (
-            p:
-                | {
-                      sinOffset?: number;
-                      sinScale?: number;
-                      cosOffset?: number;
-                      cosScale?: number;
-                      tanOffset?: number;
-                      tanScale?: number;
-                      offset?: number;
-                      scale?: number;
-                  }
-                | null
-                | undefined,
-        ): boolean =>
-            !p ||
-            ((p.sinOffset ?? 0) === 0 &&
-                (p.cosOffset ?? 0) === 0 &&
-                (p.tanOffset ?? 0) === 0 &&
-                (p.offset ?? 0) === 0 &&
-                (p.sinScale ?? 1) === 1 &&
-                (p.cosScale ?? 1) === 1 &&
-                (p.tanScale ?? 1) === 1 &&
-                (p.scale ?? 1) === 1),
-    }),
-    defineFilter({
-        name: FilterType.Equalizer,
-        scope: FilterScope.Core,
-        isDefault: (p: ReadonlyArray<{ band: number; gain: number }> | null | undefined): boolean =>
-            !p || p.length === 0 || p.every((b): boolean => b.gain === 0),
-    }),
-    defineFilter({
-        name: FilterType.ChannelMix,
-        scope: FilterScope.Core,
-        // Stereo default ({1,0,0,1}). Anything else is considered active.
-        isDefault: (
-            p: { leftToLeft?: number; leftToRight?: number; rightToLeft?: number; rightToRight?: number } | null | undefined,
-        ): boolean =>
-            !p || ((p.leftToLeft ?? 1) === 1 && (p.leftToRight ?? 0) === 0 && (p.rightToLeft ?? 0) === 0 && (p.rightToRight ?? 1) === 1),
-    }),
+    { name: FilterType.Volume, scope: FilterScope.Core },
+    { name: FilterType.LowPass, scope: FilterScope.Core },
+    { name: FilterType.Karaoke, scope: FilterScope.Core },
+    { name: FilterType.Rotation, scope: FilterScope.Core },
+    { name: FilterType.Tremolo, scope: FilterScope.Core },
+    { name: FilterType.Vibrato, scope: FilterScope.Core },
+    { name: FilterType.Timescale, scope: FilterScope.Core },
+    { name: FilterType.Distortion, scope: FilterScope.Core },
+    { name: FilterType.Equalizer, scope: FilterScope.Core },
+    { name: FilterType.ChannelMix, scope: FilterScope.Core },
 
     // Plugin: lavalink-filter-plugin (nested under `pluginFilters["lavalink-filter-plugin"]`).
-    defineFilter({
+    {
         name: FilterType.Echo,
         scope: FilterScope.Plugin,
         pluginName: PluginNames.FilterPlugin,
         capability: PluginCapabilities.Filters,
-        isDefault: (p: { delay?: number; decay?: number } | null | undefined): boolean =>
-            !p || ((p.delay ?? 0) === 0 && (p.decay ?? 0) === 0),
-    }),
-    defineFilter({
+    },
+    {
         name: FilterType.Reverb,
         scope: FilterScope.Plugin,
         pluginName: PluginNames.FilterPlugin,
         capability: PluginCapabilities.Filters,
-        isDefault: (p: { delays?: number[]; gains?: number[] } | null | undefined): boolean =>
-            !p || ((p.delays?.length ?? 0) === 0 && (p.gains?.length ?? 0) === 0),
-    }),
+    },
 
     // Plugin: lavadspx-plugin (flat under `pluginFilters.<name>`).
-    defineFilter({
-        name: FilterType.DSPXLowpass,
-        scope: FilterScope.Plugin,
-        capability: PluginCapabilities.Dspx,
-        isDefault: (p: { boostFactor?: number; cutoffFrequency?: number } | null | undefined): boolean =>
-            !p || ((p.boostFactor ?? 0) === 0 && (p.cutoffFrequency ?? 0) === 0),
-    }),
-    defineFilter({
-        name: FilterType.DSPXHighpass,
-        scope: FilterScope.Plugin,
-        capability: PluginCapabilities.Dspx,
-        isDefault: (p: { boostFactor?: number; cutoffFrequency?: number } | null | undefined): boolean =>
-            !p || ((p.boostFactor ?? 0) === 0 && (p.cutoffFrequency ?? 0) === 0),
-    }),
-    defineFilter({
+    { name: FilterType.DSPXLowpass, scope: FilterScope.Plugin, capability: PluginCapabilities.Dspx },
+    { name: FilterType.DSPXHighpass, scope: FilterScope.Plugin, capability: PluginCapabilities.Dspx },
+    {
         name: FilterType.DSPXEcho,
-        // Written flat as `pluginFilters.echo`; distinct canonical name avoids colliding with the
+        // Written flat as `pluginFilters.echo`; a distinct canonical name avoids colliding with the
         // nested `lavalink-filter-plugin` echo (see FilterType.Echo above).
         wireName: FilterType.Echo,
         scope: FilterScope.Plugin,
         capability: PluginCapabilities.Dspx,
-        isDefault: (p: { echoLength?: number; decay?: number } | null | undefined): boolean =>
-            !p || ((p.echoLength ?? 0) === 0 && (p.decay ?? 0) === 0),
-    }),
-    defineFilter({
-        name: FilterType.DSPXNormalization,
-        scope: FilterScope.Plugin,
-        capability: PluginCapabilities.Dspx,
-        isDefault: (p: { maxAmplitude?: number; adaptive?: boolean } | null | undefined): boolean =>
-            !p || ((p.maxAmplitude ?? 0) === 0 && !(p.adaptive ?? false)),
-    }),
+    },
+    { name: FilterType.DSPXNormalization, scope: FilterScope.Plugin, capability: PluginCapabilities.Dspx },
 ]);

--- a/src/types/Filters.ts
+++ b/src/types/Filters.ts
@@ -31,11 +31,6 @@ export enum FilterType {
      */
     Volume = "volume",
     /**
-     * Audio output filter.
-     * @type {string}
-     */
-    AudioOutput = "audioOutput",
-    /**
      * Low pass filter.
      * @type {string}
      */
@@ -60,11 +55,6 @@ export enum FilterType {
      * @type {string}
      */
     Vibrato = "vibrato",
-    /**
-     * Custom filter.
-     * @type {string}
-     */
-    Custom = "custom",
     /**
      * Timescale filter.
      * @type {string}
@@ -116,6 +106,48 @@ export enum FilterType {
      * @type {string}
      */
     Equalizer = "equalizer",
+}
+
+/**
+ * Options for `FilterManager.set`, controlling where the payload is written and whether the node is
+ * checked for support.
+ *
+ * | given | envelope | `validate` default |
+ * | --- | --- | --- |
+ * | nothing, registered filter | whatever the registry resolves | `true` |
+ * | nothing, unknown filter | `pluginFilters[name]` (flat) | `false` |
+ * | `plugin: true` | `pluginFilters[name]` (flat) | `false` |
+ * | `plugin: "some-plugin"` | `pluginFilters["some-plugin"][name]` | `false` |
+ * | `top: true` | `filters[name]` (top level) | `false` |
+ *
+ * Passing a routing option always wins over the registry, so an explicit envelope can be forced for a
+ * registered name too.
+ */
+export interface SetFilterOptions {
+    /**
+     * Write the filter under `pluginFilters`: `true` places it flat, a plugin name nests it under that
+     * plugin (the shape the Lavalink spec defines for plugin filters).
+     * @type {string | true | undefined}
+     */
+    plugin?: string | true;
+    /**
+     * Write the filter at the top level of the payload, next to the built-in Lavalink filters — where a
+     * fork exposes its own filters.
+     *
+     * Hoshimi does not check which server it is talking to: whether a fork-specific filter is safe to send
+     * is the node's business, so pointing a player at the right node is the caller's. Registering the
+     * filter (scope {@link FilterScope.Core}) buys routing by name and a check against the node's
+     * advertised list, when the fork does advertise it.
+     * @type {boolean | undefined}
+     */
+    top?: boolean;
+    /**
+     * Whether to check that the node advertises the filter (and installs its backing plugin) before
+     * writing. Only meaningful for registered filters — there is nothing to check an unknown key
+     * against. See the table above for the defaults.
+     * @type {boolean | undefined}
+     */
+    validate?: boolean;
 }
 
 /**
@@ -546,119 +578,29 @@ export interface FilterPluginPassSettings {
 }
 
 /**
- * The active filters on the player.
+ * The payload each built-in filter takes, used to type `FilterManager.set` and `FilterManager.get`.
+ *
+ * Keep an entry per {@link FilterType} member. A name missing from here (and from `CustomizableFilters`)
+ * resolves to `unknown`, which is what lets unregistered filters be set with any payload.
+ *
+ * Note `Echo` and `DSPXEcho` differ: both are written to the wire as `echo`, but the
+ * `lavalink-filter-plugin` one takes `{ delay, decay }` and the `lavadspx-plugin` one `{ echoLength, decay }`.
  */
-export interface EnabledPlayerFilters {
-    /**
-     * Check if any custom filter is enabled
-     * @type {boolean}
-     */
-    custom: boolean;
-    /**
-     * Check if the nightcore filter is enabled or not.
-     * @type {boolean}
-     */
-    nightcore: boolean;
-    /**
-     * Check if the vaporwave filter is enabled or not.
-     * @type {boolean}
-     */
-    vaporwave: boolean;
-    /**
-     * Check if the rotation filter is enabled or not.
-     * @type {boolean}
-     */
-    rotation: boolean;
-    /**
-     * Check if the karaoke filter is enabled or not.
-     * @type {boolean}
-     */
-    karaoke: boolean;
-    /**
-     * Check if the tremolo filter is enabled or not.
-     * @type {boolean}
-     */
-    tremolo: boolean;
-    /**
-     * Check if the vibrato filter is enabled or not.
-     * @type {boolean}
-     */
-    vibrato: boolean;
-    /**
-     * Check if the low pass filter is enabled or not.
-     * @type {boolean}
-     */
-    lowPass: boolean;
-    /**
-     * Set the audio output mode.
-     * @type {AudioOutput}
-     */
-    audioOutput: AudioOutput;
-    /**
-     * Check if the volume filter is enabled or not.
-     * @type {boolean}
-     */
-    volume: boolean;
-    /**
-     * Check if the distortion filter is enabled or not.
-     * @type {boolean}
-     */
-    distortion: boolean;
-    /**
-     * Check if the timescale filter is enabled or not.
-     * @type {boolean}
-     */
-    timescale: boolean;
-    /**
-     * The lavalink filter plugin enabled filters.
-     * @type {EnabledLavalinkFilters}
-     */
-    lavalinkFilterPlugin: EnabledLavalinkFilters;
-    /**
-     * The lavadspx plugin enabled filters.
-     * @type {EnabledDSPXPluginFilters}
-     */
-    lavalinkLavaDspxPlugin: EnabledDSPXPluginFilters;
-}
-
-/**
- * The enabled filters for the lavalink filter plugin.
- */
-export interface EnabledLavalinkFilters {
-    /**
-     * Check if the echo filter is enabled or not.
-     * @type {boolean}
-     */
-    echo: boolean;
-    /**
-     * Check if the reverb filter is enabled or not.
-     * @type {boolean}
-     */
-    reverb: boolean;
-}
-
-/**
- * The enabled filters for the lavadspx plugin.
- */
-export interface EnabledDSPXPluginFilters {
-    /**
-     * Check if the low pass filter is enabled or not.
-     * @type {boolean}
-     */
-    lowPass: boolean;
-    /**
-     * Check if the high pass filter is enabled or not.
-     * @type {boolean}
-     */
-    highPass: boolean;
-    /**
-     * Check if the normalization filter is enabled or not.
-     * @type {boolean}
-     */
-    normalization: boolean;
-    /**
-     * Check if the echo filter is enabled or not.
-     * @type {boolean}
-     */
-    echo: boolean;
+export interface FilterPayloads {
+    [FilterType.Volume]: number;
+    [FilterType.Equalizer]: EQBandSettings[];
+    [FilterType.Karaoke]: KaraokeSettings;
+    [FilterType.Timescale]: TimescaleSettings;
+    [FilterType.Tremolo]: FreqSettings;
+    [FilterType.Vibrato]: FreqSettings;
+    [FilterType.Rotation]: RotationSettings;
+    [FilterType.Distortion]: DistortionSettings;
+    [FilterType.ChannelMix]: ChannelMixSettings;
+    [FilterType.LowPass]: LowPassSettings;
+    [FilterType.Echo]: LavalinkFilterPluginEchoSettings;
+    [FilterType.Reverb]: LavalinkFilterPluginReverbSettings;
+    [FilterType.DSPXLowpass]: Partial<FilterPluginPassSettings>;
+    [FilterType.DSPXHighpass]: Partial<FilterPluginPassSettings>;
+    [FilterType.DSPXEcho]: EchoSettings;
+    [FilterType.DSPXNormalization]: NormalizationSettings;
 }

--- a/src/types/Node.ts
+++ b/src/types/Node.ts
@@ -1199,9 +1199,9 @@ export interface NodeSessionOptions {
 export interface NodePlayerMoveOptions {
     /**
      * The node sort type or a custom function to filter the nodes to move the players to when a node gets disconnected.
-     * @type {PlayerMoveFilter | undefined}
+     * @type {NodeSortFilter | undefined}
      */
-    filterBy?: PlayerMoveFilter;
+    filterBy?: NodeSortFilter;
     /**
      * Whether to move the players to another node if the node gets disconnected.
      * @type {boolean}
@@ -1359,9 +1359,14 @@ export interface NodeJSON {
 }
 
 /**
+ * The type for the node sort function.
+ */
+export type NodeSortFunction = (node: NodeStructure) => number;
+
+/**
  * The type for the player move filter.
  */
-export type PlayerMoveFilter = NodeSortTypes | ((node: NodeStructure) => number);
+export type NodeSortFilter = NodeSortTypes | NodeSortFunction;
 
 /**
  * The type for the unresolved track info.

--- a/src/types/Node.ts
+++ b/src/types/Node.ts
@@ -1254,14 +1254,6 @@ export interface NodeHeartbeatOptions {
      * @default 30000
      */
     interval?: number;
-
-    /**
-     * Maximum time in milliseconds between Lavalink `stats` messages before
-     * the socket is considered dead. Stats are sent every 60s, so 65000
-     * leaves a 5s buffer. Set to 0 to disable.
-     * @default 65000
-     */
-    statsTimeout?: number;
 }
 
 /**

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -1,6 +1,6 @@
 import PackageJson from "../../package.json";
 import { QueueMemoryStorage } from "../classes/storage/QueueMemory";
-import type { ChannelMixSettings, FilterSettings } from "../types/Filters";
+import type { ChannelMixSettings } from "../types/Filters";
 import { AudioOutput } from "../types/Filters";
 import { type RequiredHoshimiOptions, SearchSources } from "../types/Manager";
 import { NodeSortTypes, type UserAgent } from "../types/Node";
@@ -78,80 +78,6 @@ export const DefaultFilterPreset = Object.freeze({
 });
 
 /**
- * The default filter settings.
- * @type {Readonly<FilterSettings>} DefaultFilters
- */
-export const DefaultPlayerFilters: Readonly<FilterSettings> = Object.freeze<FilterSettings>({
-    volume: 1,
-    equalizer: [],
-    channelMix: AudioOutputData.stereo,
-    lowPass: {
-        smoothing: 0,
-    },
-    karaoke: {
-        level: 0,
-        monoLevel: 0,
-        filterBand: 0,
-        filterWidth: 0,
-    },
-    timescale: {
-        speed: 1,
-        pitch: 1,
-        rate: 1,
-    },
-    rotation: {
-        rotationHz: 0,
-    },
-    tremolo: {
-        frequency: 0,
-        depth: 0,
-    },
-    vibrato: {
-        frequency: 0,
-        depth: 0,
-    },
-    pluginFilters: {
-        "high-pass": {
-            boostFactor: 0,
-            cutoffFrequency: 0,
-        },
-        "low-pass": {
-            boostFactor: 0,
-            cutoffFrequency: 0,
-        },
-        "lavalink-filter-plugin": {
-            echo: {
-                delay: 0,
-                decay: 0,
-            },
-            reverb: {
-                delays: [],
-                gains: [],
-            },
-        },
-        echo: {
-            decay: 0,
-            delay: 0,
-            echoLength: 0,
-        },
-        normalization: {
-            adaptive: false,
-            maxAmplitude: 0,
-        },
-    },
-    distortion: {
-        cosOffset: 0,
-        sinOffset: 0,
-        tanOffset: 0,
-        offset: 0,
-        scale: 1,
-        cosScale: 1,
-        sinScale: 1,
-        tanScale: 1,
-    },
-});
-
-/**
  * The valid loop mode values.
  * @type {LoopMode[]}
  */
@@ -183,7 +109,6 @@ export const HoshimiDefaultOptions: Readonly<RequiredHoshimiOptions> = Object.fr
         },
         heartbeatOptions: {
             interval: 30000,
-            statsTimeout: 65000,
         },
     },
     queueOptions: {

--- a/src/util/events/player.ts
+++ b/src/util/events/player.ts
@@ -44,8 +44,8 @@ async function onEnd(this: PlayerStructure, updateCurrent: boolean = true): Prom
         );
     }
 
-    if (this.loop === LoopMode.Track && this.queue.current) this.queue.unshift(this.queue.current);
-    if (this.loop === LoopMode.Queue && this.queue.current) this.queue.add(this.queue.current);
+    if (this.loop === LoopMode.Track && this.queue.current) await this.queue.unshift(this.queue.current);
+    if (this.loop === LoopMode.Queue && this.queue.current) await this.queue.add(this.queue.current);
 
     if (!this.queue.current && updateCurrent) this.queue.current = await this.queue.utils.build(await this.queue.shift());
 

--- a/src/util/functions/autoplay.ts
+++ b/src/util/functions/autoplay.ts
@@ -54,10 +54,12 @@ export async function autoplayFn(player: PlayerStructure, lastTrack: TrackResolv
                 requester: lastTrack.requester,
             });
 
-            if (tracks.length) {
-                const index: number = Math.floor(Math.random() * tracks.length);
+            const candidates: TrackStructure[] = filter(tracks);
 
-                const track: TrackStructure | undefined = filter(tracks)[index];
+            if (candidates.length) {
+                const index: number = Math.floor(Math.random() * candidates.length);
+
+                const track: TrackStructure | undefined = candidates[index];
                 if (!track) return;
 
                 await player.queue.add(track);
@@ -70,9 +72,12 @@ export async function autoplayFn(player: PlayerStructure, lastTrack: TrackResolv
             const query = `https://www.youtube.com/watch?v=${lastTrack.info.identifier}&list=RD${lastTrack.info.identifier}`;
             const search: QueryResult = await player.search({ query, requester: lastTrack.requester });
 
-            if (search.tracks.length) {
-                const random: number = Math.floor(Math.random() * search.tracks.length);
-                const tracks: TrackStructure[] = filter(search.tracks).slice(random, random + limit);
+            const candidates: TrackStructure[] = filter(search.tracks);
+
+            if (candidates.length) {
+                // Start from a random offset, pulled back so a start near the end still yields up to `limit`.
+                const start: number = Math.max(0, Math.min(Math.floor(Math.random() * candidates.length), candidates.length - limit));
+                const tracks: TrackStructure[] = candidates.slice(start, start + limit);
 
                 await player.queue.add(tracks);
             }

--- a/src/util/functions/filters.ts
+++ b/src/util/functions/filters.ts
@@ -1,184 +1,206 @@
+import { PlayerError } from "../../classes/Errors";
 import type { FilterManager } from "../../classes/player/filters/Manager";
-import { type FilterRegistration, FilterRegistry, FilterScope } from "../../registry/FiltersRegistry";
-import type { FilterSettings } from "../../types/Filters";
-
-/**
- * Build the wire payload from the manager's {@link FilterManager.data} — stripping default-state entries,
- * plugin filters the node cannot host, and top-level filters the node does not advertise — then send it
- * via the REST `updatePlayer` endpoint.
- * @this {FilterManager}
- * @returns {Promise<void>}
- */
-async function commit(this: FilterManager): Promise<void> {
-    if (!this.player.node.sessionId) return;
-
-    // `data.equalizer` is the source of truth (kept in sync with `this.bands` by setEQBand/clearEQBands).
-    const filters: FilterSettings = { ...this.data };
-
-    // Strip default-state top-level filters via the registry.
-    for (const key of Object.keys(filters)) {
-        if (key === "pluginFilters") continue;
-        const value: unknown = (filters as Record<string, unknown>)[key];
-        if (FilterRegistry.isDefault(key, value)) {
-            delete (filters as Record<string, unknown>)[key];
-        }
-    }
-
-    // Strip default-state plugin filters and prune empty envelopes.
-    const pluginFilters: Record<string, unknown> | undefined = filters.pluginFilters as Record<string, unknown> | undefined;
-    if (pluginFilters) {
-        const stripped: Record<string, unknown> = { ...pluginFilters };
-        for (const key of Object.keys(stripped)) {
-            const value: unknown = stripped[key];
-            if (isNestedPluginEnvelope(key, value)) {
-                // Nested plugin envelope: prune each child filter individually.
-                const nested: Record<string, unknown> = { ...(value as Record<string, unknown>) };
-                for (const inner of Object.keys(nested)) {
-                    if (FilterRegistry.isDefault(inner, nested[inner])) delete nested[inner];
-                }
-                if (Object.keys(nested).length === 0) delete stripped[key];
-                else stripped[key] = nested;
-            } else if (FilterRegistry.isDefaultFlatPlugin(key, value)) {
-                delete stripped[key];
-            }
-        }
-        if (Object.keys(stripped).length === 0) delete filters.pluginFilters;
-        else filters.pluginFilters = stripped;
-    }
-
-    // Drop plugin filters the node cannot host (e.g. after moving to a node without the backing plugin).
-    // Only prune once the node has reported its info, so we never drop filters on a not-yet-ready node.
-    const hostable: Record<string, unknown> | undefined = filters.pluginFilters as Record<string, unknown> | undefined;
-    if (hostable && this.player.node.info) {
-        for (const key of Object.keys(hostable)) {
-            const value: unknown = hostable[key];
-            if (isNestedPluginEnvelope(key, value)) {
-                // Nested envelope: keep only inner filters whose plugin resolves for this node.
-                const nested: Record<string, unknown> = { ...(value as Record<string, unknown>) };
-                for (const inner of Object.keys(nested)) {
-                    if (!FilterRegistry.resolve(inner, this.player.node)) delete nested[inner];
-                }
-                if (Object.keys(nested).length === 0) delete hostable[key];
-                else hostable[key] = nested;
-            } else if (!FilterRegistry.canHostFlatPlugin(this.player.node, key)) {
-                delete hostable[key];
-            }
-        }
-        if (Object.keys(hostable).length === 0) delete filters.pluginFilters;
-    }
-
-    // Drop top-level filters the node does not advertise (vendor-scoped on a recognised fork is kept).
-    const advertised: ReadonlyArray<string> = this.player.node.info?.filters ?? [];
-    for (const key of Object.keys(filters)) {
-        if (key === "pluginFilters") continue;
-        const entry: FilterRegistration | null = FilterRegistry.resolve(key, this.player.node);
-        if (entry?.scope === FilterScope.Vendor && this.player.node.isNodelink()) continue;
-        if (!advertised.some((f): boolean => f === key)) {
-            delete (filters as Record<string, unknown>)[key];
-        }
-    }
-
-    await this.player.updatePlayer({ playerOptions: { filters } });
-}
-
-/**
- * Detect whether a `pluginFilters` key is a nested-plugin envelope (e.g. `"lavalink-filter-plugin"`)
- * rather than a flat filter (e.g. `"echo"`). A key that is not any registered filter's wire key is a
- * plugin-name wrapper holding nested filters (decided structurally, independent of installed plugins).
- * @param {string} key The `pluginFilters` key to inspect.
- * @param {unknown} value The value stored under that key.
- * @returns {boolean} Whether the key wraps nested filters.
- */
-function isNestedPluginEnvelope(key: string, value: unknown): boolean {
-    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-    return !FilterRegistry.isWireKey(key);
-}
-
-/**
- * Write `payload` into the correct envelope for the given entry.
- * @this {FilterManager}
- * @param {FilterRegistration} entry The resolved registration describing where the filter lives.
- * @param {unknown} payload The payload to write.
- * @returns {void}
- */
-function writeToEnvelope(this: FilterManager, entry: FilterRegistration, payload: unknown): void {
-    const name: string = String(entry.wireName ?? entry.name);
-    if (entry.scope === FilterScope.Core || entry.scope === FilterScope.Vendor) {
-        (this.data as Record<string, unknown>)[name] = payload;
-        return;
-    }
-    // Plugin
-    if (!this.data.pluginFilters) this.data.pluginFilters = {};
-    const pf: Record<string, unknown> = this.data.pluginFilters as Record<string, unknown>;
-    if (entry.pluginName) {
-        const nestedKey: string = String(entry.pluginName);
-        const current: unknown = pf[nestedKey];
-        const next: Record<string, unknown> =
-            current && typeof current === "object" && !Array.isArray(current) ? { ...(current as Record<string, unknown>) } : {};
-        next[name] = payload;
-        pf[nestedKey] = next;
-    } else {
-        pf[name] = payload;
-    }
-}
-
-/**
- * Read the current payload for the given entry from the envelope.
- * @this {FilterManager}
- * @param {FilterRegistration} entry The resolved registration describing where the filter lives.
- * @returns {unknown} The stored payload, or `undefined` when absent.
- */
-function readFromEnvelope(this: FilterManager, entry: FilterRegistration): unknown {
-    const name: string = String(entry.wireName ?? entry.name);
-    if (entry.scope === FilterScope.Core || entry.scope === FilterScope.Vendor) {
-        return (this.data as Record<string, unknown>)[name];
-    }
-    const pf: Record<string, unknown> | undefined = this.data.pluginFilters as Record<string, unknown> | undefined;
-    if (!pf) return undefined;
-    if (entry.pluginName) {
-        const nested: unknown = pf[String(entry.pluginName)];
-        if (!nested || typeof nested !== "object" || Array.isArray(nested)) return undefined;
-        return (nested as Record<string, unknown>)[name];
-    }
-    return pf[name];
-}
-
-/**
- * Remove the filter described by `entry` from the envelope, pruning empty wrappers.
- * @this {FilterManager}
- * @param {FilterRegistration} entry The resolved registration describing where the filter lives.
- * @returns {void}
- */
-function clearFromEnvelope(this: FilterManager, entry: FilterRegistration): void {
-    const name: string = String(entry.wireName ?? entry.name);
-    if (entry.scope === FilterScope.Core || entry.scope === FilterScope.Vendor) {
-        delete (this.data as Record<string, unknown>)[name];
-        return;
-    }
-    const pf: Record<string, unknown> | undefined = this.data.pluginFilters as Record<string, unknown> | undefined;
-    if (!pf) return;
-    if (entry.pluginName) {
-        const nestedKey: string = String(entry.pluginName);
-        const nested: unknown = pf[nestedKey];
-        if (!nested || typeof nested !== "object" || Array.isArray(nested)) return;
-        const next: Record<string, unknown> = { ...(nested as Record<string, unknown>) };
-        delete next[name];
-        if (Object.keys(next).length === 0) delete pf[nestedKey];
-        else pf[nestedKey] = next;
-    } else {
-        delete pf[name];
-    }
-}
+import { FilterRegistry, type FilterRoute, FilterScope, type RegistryFilterName } from "../../registry/FiltersRegistry";
+import type { FilterSettings, SetFilterOptions } from "../../types/Filters";
 
 /**
  * Internal grouping of the {@link FilterManager} wire/envelope helpers. Kept off the class (no private
- * members) per the project convention; the state-bound entries are invoked with `.call(manager)`.
+ * members) per the project convention, with the manager passed explicitly rather than through `this`:
+ * these are always invoked directly, unlike the socket/player handlers in `util/events`, which have to
+ * be `this`-bound because they are registered as callbacks.
  * Not part of the public package surface.
  */
 export const FilterPayload = {
-    commit,
-    isNestedPluginEnvelope,
-    writeToEnvelope,
-    readFromEnvelope,
-    clearFromEnvelope,
+    /**
+     * Build the wire payload from the manager's {@link FilterManager.data} — pruning empty envelopes,
+     * plugin filters the node cannot host, and registered top-level filters the node does not advertise
+     * — then send it via the REST `updatePlayer` endpoint.
+     * @param {FilterManager} manager The filter manager holding the payload.
+     * @returns {Promise<void>}
+     */
+    async commit(manager: FilterManager): Promise<void> {
+        if (!manager.player.node.sessionId) return;
+
+        // A key is only present while its filter is active, so the payload needs no default-state
+        // stripping: what `data` holds is what the node should apply.
+        // `data.equalizer` is the source of truth (kept in sync with `manager.bands` by setEQBand/clearEQBands).
+        const filters: FilterSettings = { ...manager.data };
+
+        // Prune empty envelopes a caller may have left behind by editing `data` by hand. Copied rather
+        // than mutated in place so the live payload is never touched.
+        const pluginFilters: Record<string, unknown> | undefined = filters.pluginFilters as Record<string, unknown> | undefined;
+        if (pluginFilters) {
+            const stripped: Record<string, unknown> = { ...pluginFilters };
+            for (const key of Object.keys(stripped)) {
+                const value: unknown = stripped[key];
+                if (FilterPayload.isNested(key, value) && Object.keys(value as Record<string, unknown>).length === 0) {
+                    delete stripped[key];
+                }
+            }
+            if (Object.keys(stripped).length === 0) delete filters.pluginFilters;
+            else filters.pluginFilters = stripped;
+        }
+
+        // Drop plugin filters the node cannot host (e.g. after moving to a node without the backing plugin).
+        // Only prune once the node has reported its info, so we never drop filters on a not-yet-ready node.
+        const hostable: Record<string, unknown> | undefined = filters.pluginFilters as Record<string, unknown> | undefined;
+        if (hostable && manager.player.node.info) {
+            for (const key of Object.keys(hostable)) {
+                const value: unknown = hostable[key];
+                if (FilterPayload.isNested(key, value)) {
+                    // Nested envelope: keep only inner filters whose plugin resolves for this node.
+                    // Names the registry never heard of are left alone, same as unknown flat keys.
+                    const nested: Record<string, unknown> = { ...(value as Record<string, unknown>) };
+                    for (const inner of Object.keys(nested)) {
+                        if (!FilterRegistry.isKnown(inner)) continue;
+                        if (!FilterRegistry.resolve(inner, manager.player.node)) delete nested[inner];
+                    }
+                    if (Object.keys(nested).length === 0) delete hostable[key];
+                    else hostable[key] = nested;
+                } else if (!FilterRegistry.canHostFlatPlugin(manager.player.node, key)) {
+                    delete hostable[key];
+                }
+            }
+            if (Object.keys(hostable).length === 0) delete filters.pluginFilters;
+        }
+
+        // Drop top-level filters the node does not advertise, but only once it has actually reported its
+        // filter list: an absent one means "unknown", not "advertises nothing". Keys the registry does not
+        // know are left alone — the same treatment flat plugin filters get in canHostFlatPlugin — so a
+        // fork-specific or ad-hoc filter is never silently dropped.
+        const advertised: ReadonlyArray<string> | undefined = manager.player.node.info?.filters;
+        if (advertised) {
+            for (const key of Object.keys(filters)) {
+                if (key === "pluginFilters") continue;
+                if (!FilterRegistry.isKnown(key)) continue;
+                if (!advertised.some((f): boolean => f === key)) {
+                    delete (filters as Record<string, unknown>)[key];
+                }
+            }
+        }
+
+        await manager.player.updatePlayer({ playerOptions: { filters } });
+    },
+
+    /**
+     * Detect whether a `pluginFilters` key is a nested-plugin envelope (e.g. `"lavalink-filter-plugin"`)
+     * rather than a filter payload written flat (e.g. `"echo"`).
+     *
+     * Decided by asking the registry whether the key names a plugin that owns nested filters, not by
+     * ruling out known wire keys: an unregistered key is a filter of its own, not a wrapper, so an
+     * ad-hoc filter is never mistaken for an envelope and pruned away.
+     * @param {string} key The `pluginFilters` key to inspect.
+     * @param {unknown} value The value stored under that key.
+     * @returns {boolean} Whether the key wraps nested filters.
+     */
+    isNested(key: string, value: unknown): boolean {
+        if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+        return FilterRegistry.isPluginName(key);
+    },
+
+    /**
+     * Work out where a filter's payload belongs.
+     *
+     * A routing option (`plugin`/`top`) always wins, so an explicit envelope can be forced even for a
+     * registered name. Otherwise the registry decides, and a name it does not know falls back to a flat
+     * `pluginFilters` entry — the extension point the Lavalink v4 spec defines.
+     * @param {FilterManager} manager The filter manager, for node context.
+     * @param {RegistryFilterName} name The filter name (or alias).
+     * @param {SetFilterOptions} [options={}] The routing options.
+     * @throws {PlayerError} If both `plugin` and `top` are given.
+     * @returns {FilterRoute} The envelope coordinates for the filter.
+     */
+    route(manager: FilterManager, name: RegistryFilterName, options: SetFilterOptions = {}): FilterRoute {
+        const key: string = String(name);
+
+        if (typeof options.plugin !== "undefined" && options.top)
+            throw new PlayerError("The filter options 'plugin' and 'top' are mutually exclusive.");
+
+        if (options.top) return { name: key, scope: FilterScope.Core };
+        if (typeof options.plugin !== "undefined") {
+            if (typeof options.plugin === "string") return { name: key, scope: FilterScope.Plugin, pluginName: options.plugin };
+            return { name: key, scope: FilterScope.Plugin };
+        }
+
+        return FilterRegistry.resolve(name, manager.player.node) ?? { name: key, scope: FilterScope.Plugin };
+    },
+
+    /**
+     * Write `payload` into the envelope described by `route`.
+     * @param {FilterManager} manager The filter manager holding the payload.
+     * @param {FilterRoute} route Where the filter lives.
+     * @param {unknown} payload The payload to write.
+     * @returns {void}
+     */
+    write(manager: FilterManager, route: FilterRoute, payload: unknown): void {
+        const name: string = String(route.wireName ?? route.name);
+        if (route.scope === FilterScope.Core) {
+            (manager.data as Record<string, unknown>)[name] = payload;
+            return;
+        }
+        // Plugin
+        if (!manager.data.pluginFilters) manager.data.pluginFilters = {};
+        const pf: Record<string, unknown> = manager.data.pluginFilters as Record<string, unknown>;
+        if (route.pluginName) {
+            const nestedKey: string = String(route.pluginName);
+            const current: unknown = pf[nestedKey];
+            const next: Record<string, unknown> =
+                current && typeof current === "object" && !Array.isArray(current) ? { ...(current as Record<string, unknown>) } : {};
+            next[name] = payload;
+            pf[nestedKey] = next;
+        } else {
+            pf[name] = payload;
+        }
+    },
+
+    /**
+     * Read the current payload stored at `route`.
+     * @param {FilterManager} manager The filter manager holding the payload.
+     * @param {FilterRoute} route Where the filter lives.
+     * @returns {unknown} The stored payload, or `undefined` when absent.
+     */
+    read(manager: FilterManager, route: FilterRoute): unknown {
+        const name: string = String(route.wireName ?? route.name);
+        if (route.scope === FilterScope.Core) {
+            return (manager.data as Record<string, unknown>)[name];
+        }
+        const pf: Record<string, unknown> | undefined = manager.data.pluginFilters as Record<string, unknown> | undefined;
+        if (!pf) return undefined;
+        if (route.pluginName) {
+            const nested: unknown = pf[String(route.pluginName)];
+            if (!nested || typeof nested !== "object" || Array.isArray(nested)) return undefined;
+            return (nested as Record<string, unknown>)[name];
+        }
+        return pf[name];
+    },
+
+    /**
+     * Remove the filter at `route` from the payload, pruning empty wrappers.
+     * @param {FilterManager} manager The filter manager holding the payload.
+     * @param {FilterRoute} route Where the filter lives.
+     * @returns {void}
+     */
+    clear(manager: FilterManager, route: FilterRoute): void {
+        const name: string = String(route.wireName ?? route.name);
+        if (route.scope === FilterScope.Core) {
+            delete (manager.data as Record<string, unknown>)[name];
+            return;
+        }
+        const pf: Record<string, unknown> | undefined = manager.data.pluginFilters as Record<string, unknown> | undefined;
+        if (!pf) return;
+        if (route.pluginName) {
+            const nestedKey: string = String(route.pluginName);
+            const nested: unknown = pf[nestedKey];
+            if (!nested || typeof nested !== "object" || Array.isArray(nested)) return;
+            const next: Record<string, unknown> = { ...(nested as Record<string, unknown>) };
+            delete next[name];
+            if (Object.keys(next).length === 0) delete pf[nestedKey];
+            else pf[nestedKey] = next;
+        } else {
+            delete pf[name];
+        }
+
+        // Presence is what marks a filter active, so an emptied container must not linger either.
+        if (Object.keys(pf).length === 0) delete manager.data.pluginFilters;
+    },
 } as const;

--- a/src/util/functions/validations.ts
+++ b/src/util/functions/validations.ts
@@ -2,7 +2,7 @@ import { OptionError } from "../../classes/Errors";
 import { QueueStorageAdapter } from "../../classes/storage/adapters/QueueAdapter";
 import { type ParsedQuery, SourceRegistry } from "../../registry/SourceRegistry";
 import type { HoshimiOptions, SearchSource } from "../../types/Manager";
-import type { NodeOptions, PlayerMoveFilter, SearchQuery, SourceName } from "../../types/Node";
+import type { NodeOptions, NodeSortFilter, SearchQuery, SourceName } from "../../types/Node";
 import type { PlayerOptions } from "../../types/Player";
 import { UrlRegex } from "../constants";
 import { isPlainObject } from "./utils";
@@ -110,7 +110,7 @@ function validateManagerOptions(options: HoshimiOptions): void {
             if (typeof options.nodeOptions.moveOptions.move !== "undefined" && typeof options.nodeOptions.moveOptions.move !== "boolean")
                 throw new OptionError("The manager option 'options.nodeOptions.moveOptions.move' must be a boolean.");
             if (typeof options.nodeOptions.moveOptions.filterBy !== "undefined") {
-                const filterBy: PlayerMoveFilter = options.nodeOptions.moveOptions.filterBy;
+                const filterBy: NodeSortFilter = options.nodeOptions.moveOptions.filterBy;
                 if (typeof filterBy !== "string" && typeof filterBy !== "function")
                     throw new OptionError(
                         "The manager option 'options.nodeOptions.moveOptions.filterBy' must be a valid NodeSortTypes string or a function.",

--- a/src/util/functions/validations.ts
+++ b/src/util/functions/validations.ts
@@ -9,6 +9,35 @@ import { isPlainObject } from "./utils";
 
 /**
  *
+ * Check whether an optional numeric option is a non-negative integer.
+ *
+ * Every numeric option in Hoshimi is a millisecond timeout, a second timeout, a counter or a size, so
+ * `NaN`, `Infinity`, fractional and negative values are always wrong — and they fail silently rather
+ * than loudly: `slice(0, NaN)` empties the history, `retryAmount: NaN` never reaches `0` so the node
+ * reconnects forever, and `heartbeat.interval: NaN` disables the heartbeat without a word.
+ * @param {unknown} value The value to check.
+ * @returns {boolean} True when the value is absent or a non-negative integer.
+ */
+function isOptionalNonNegativeInteger(value: unknown): boolean {
+    if (typeof value === "undefined") return true;
+    return Number.isInteger(value) && (value as number) >= 0;
+}
+
+/**
+ *
+ * Assert that an optional manager option is a non-negative integer.
+ * @param {unknown} value The value to validate.
+ * @param {string} option The dotted option path, used in the error message.
+ * @throws {OptionError} If the value is present and not a non-negative integer.
+ * @returns {void}
+ */
+function assertNonNegativeInteger(value: unknown, option: string): void {
+    if (isOptionalNonNegativeInteger(value)) return;
+    throw new OptionError(`The manager option '${option}' must be a non-negative integer.`);
+}
+
+/**
+ *
  * Validate if the node options are correct.
  * @param {NodeOptions} options The node options to validate.
  * @returns {boolean} If the node options are correct.
@@ -16,18 +45,19 @@ import { isPlainObject } from "./utils";
 function isNode(options: NodeOptions): boolean {
     return (
         typeof options.host === "string" &&
-        typeof options.port === "number" &&
+        Number.isInteger(options.port) &&
+        options.port > 0 &&
+        options.port <= 65535 &&
         typeof options.password === "string" &&
         (typeof options.id === "string" || typeof options.id === "undefined") &&
         (typeof options.secure === "boolean" || typeof options.secure === "undefined") &&
         (typeof options.sessionId === "string" || typeof options.sessionId === "undefined") &&
-        (typeof options.retryAmount === "number" || typeof options.retryAmount === "undefined") &&
-        (typeof options.retryDelay === "number" || typeof options.retryDelay === "undefined") &&
-        (typeof options.restTimeout === "number" || typeof options.restTimeout === "undefined") &&
+        isOptionalNonNegativeInteger(options.retryAmount) &&
+        isOptionalNonNegativeInteger(options.retryDelay) &&
+        isOptionalNonNegativeInteger(options.restTimeout) &&
         (typeof options.heartbeat === "object" || typeof options.heartbeat === "undefined") &&
         (typeof options.closeOnError === "boolean" || typeof options.closeOnError === "undefined") &&
-        (typeof options.heartbeat?.interval === "number" || typeof options.heartbeat?.interval === "undefined") &&
-        (typeof options.heartbeat?.statsTimeout === "number" || typeof options.heartbeat?.statsTimeout === "undefined")
+        isOptionalNonNegativeInteger(options.heartbeat?.interval)
     );
 }
 
@@ -46,8 +76,8 @@ function validateManagerOptions(options: HoshimiOptions): void {
         throw new OptionError("The manager option 'options.defaultSearchSource' Must be a valid search source.");
 
     if (isPlainObject(options.queueOptions)) {
-        if (typeof options.queueOptions.maxHistory !== "undefined" && typeof options.queueOptions.maxHistory !== "number")
-            throw new OptionError("The manager option 'options.queueOptions.maxHistory' must be a number.");
+        assertNonNegativeInteger(options.queueOptions.maxHistory, "options.queueOptions.maxHistory");
+
         if (typeof options.queueOptions.autoplayFn !== "undefined" && typeof options.queueOptions.autoplayFn !== "function")
             throw new OptionError("The manager option 'options.queueOptions.autoplayFn' must be a function.");
         if (typeof options.queueOptions.storage !== "undefined" && !(options.queueOptions.storage instanceof QueueStorageAdapter))
@@ -92,11 +122,9 @@ function validateManagerOptions(options: HoshimiOptions): void {
                 typeof options.nodeOptions.sessionOptions.resumable !== "boolean"
             )
                 throw new OptionError("The manager option 'options.nodeOptions.resumable' must be a boolean.");
-            if (
-                typeof options.nodeOptions.sessionOptions.timeout !== "undefined" &&
-                typeof options.nodeOptions.sessionOptions.timeout !== "number"
-            )
-                throw new OptionError("The manager option 'options.nodeOptions.resumeTimeout' must be a number.");
+
+            assertNonNegativeInteger(options.nodeOptions.sessionOptions.timeout, "options.nodeOptions.sessionOptions.timeout");
+
             if (
                 typeof options.nodeOptions.sessionOptions.byLibrary !== "undefined" &&
                 typeof options.nodeOptions.sessionOptions.byLibrary !== "boolean"
@@ -119,16 +147,7 @@ function validateManagerOptions(options: HoshimiOptions): void {
         }
 
         if (isPlainObject(options.nodeOptions.heartbeatOptions)) {
-            if (
-                typeof options.nodeOptions.heartbeatOptions.interval !== "undefined" &&
-                typeof options.nodeOptions.heartbeatOptions.interval !== "number"
-            )
-                throw new OptionError("The manager option 'options.nodeOptions.heartbeatOptions.interval' must be a number.");
-            if (
-                typeof options.nodeOptions.heartbeatOptions.statsTimeout !== "undefined" &&
-                typeof options.nodeOptions.heartbeatOptions.statsTimeout !== "number"
-            )
-                throw new OptionError("The manager option 'options.nodeOptions.heartbeatOptions.statsTimeout' must be a number.");
+            assertNonNegativeInteger(options.nodeOptions.heartbeatOptions.interval, "options.nodeOptions.heartbeatOptions.interval");
         }
 
         if (typeof options.nodeOptions.userAgent !== "undefined" && typeof options.nodeOptions.userAgent !== "string")
@@ -136,10 +155,8 @@ function validateManagerOptions(options: HoshimiOptions): void {
     }
 
     if (isPlainObject(options.restOptions)) {
-        if (typeof options.restOptions.resumeTimeout !== "undefined" && typeof options.restOptions.resumeTimeout !== "number")
-            throw new OptionError("The manager option 'options.restOptions.resumeTimeout' must be a number.");
-        if (typeof options.restOptions.restTimeout !== "undefined" && typeof options.restOptions.restTimeout !== "number")
-            throw new OptionError("The manager option 'options.restOptions.restTimeout' must be a number.");
+        assertNonNegativeInteger(options.restOptions.resumeTimeout, "options.restOptions.resumeTimeout");
+        assertNonNegativeInteger(options.restOptions.restTimeout, "options.restOptions.restTimeout");
     }
 }
 
@@ -162,14 +179,15 @@ function validateQuery(search: SearchQuery): string {
 
     const query: string = search.query.trim();
 
+    // A plain URL goes to the node untouched. This has to be checked before parsing a source prefix:
+    // `http://x.com/a.mp3` matches the registered `http` source and would lose its scheme.
+    if (UrlRegex.test(query)) return query;
+
     const parsed: ParsedQuery | null = SourceRegistry.parseQuery(query);
     if (parsed) {
         if (UrlRegex.test(parsed.value)) return parsed.value;
         return SourceRegistry.createIdentifier(parsed.source, parsed.value);
     }
-
-    const isUrl: boolean = UrlRegex.test(query);
-    if (isUrl) return query;
 
     return SourceRegistry.createIdentifier(search.source, query);
 }
@@ -190,8 +208,10 @@ function validatePlayerOptions(options: PlayerOptions): void {
         throw new OptionError("The player option 'options.selfDeaf' Must be a boolean.");
     if (typeof options.selfMute !== "undefined" && typeof options.selfMute !== "boolean")
         throw new OptionError("The player option 'options.selfMute' Mute must be a boolean.");
-    if (typeof options.volume !== "undefined" && typeof options.volume !== "number")
-        throw new OptionError("The player option 'options.volume' Must be a number.");
+    // Not the integer helper: `Player.setVolume` rounds and clamps, so a fractional volume is valid.
+    // NaN, Infinity and negatives are not — they would reach the node as a broken volume.
+    if (typeof options.volume !== "undefined" && (!Number.isFinite(options.volume) || options.volume < 0))
+        throw new OptionError("The player option 'options.volume' must be a non-negative number.");
 }
 
 /**

--- a/tests/core/hoshimi.test.ts
+++ b/tests/core/hoshimi.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { HoshimiDefaultOptions, type HoshimiOptions } from "../../src";
-import { ManagerError } from "../../src/classes/Errors";
+import { ManagerError, OptionError } from "../../src/classes/Errors";
 import { Hoshimi } from "../../src/classes/Hoshimi";
 import { State } from "../../src/types/Node";
 
@@ -14,6 +14,28 @@ function createOptions() {
 describe("Hoshimi", () => {
     it("throws ManagerError when options are missing", () => {
         expect(() => new Hoshimi(undefined as never)).toThrow(ManagerError);
+    });
+
+    it("throws OptionError when maxHistory is not a non-negative integer", () => {
+        for (const maxHistory of [Number.NaN, -1, 2.5, Number.POSITIVE_INFINITY, "25"]) {
+            expect(() => new Hoshimi({ ...createOptions(), queueOptions: { maxHistory } } as never)).toThrow(OptionError);
+        }
+
+        expect(() => new Hoshimi({ ...createOptions(), queueOptions: { maxHistory: 0 } } as never)).not.toThrow();
+        expect(new Hoshimi({ ...createOptions(), queueOptions: { maxHistory: 10 } } as never).options.queueOptions.maxHistory).toBe(10);
+    });
+
+    it("init rejects a missing client id and the placeholder default", () => {
+        const manager = new Hoshimi(createOptions());
+
+        expect(manager.options.client.id).toBe(HoshimiDefaultOptions.client.id);
+
+        expect(() => manager.init({} as never)).toThrow(ManagerError);
+        expect(() => manager.init({ id: HoshimiDefaultOptions.client.id })).toThrow(ManagerError);
+        expect(() => manager.init({ id: "" })).toThrow(ManagerError);
+
+        expect(manager.ready).toBe(false);
+        expect(manager.nodeManager.nodes.size).toBe(0);
     });
 
     it("sets default options when constructed", () => {

--- a/tests/core/validations.test.ts
+++ b/tests/core/validations.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { OptionError } from "../../src/classes/Errors";
+import { type HoshimiOptions, SearchSources } from "../../src/types/Manager";
+import type { NodeOptions } from "../../src/types/Node";
+import { Validations } from "../../src/util/functions/validations";
+
+function createOptions(): HoshimiOptions {
+    return {
+        sendPayload: () => {},
+        nodes: [{ host: "localhost", port: 2333, password: "pass" }],
+    };
+}
+
+describe("Validations.validateQuery", () => {
+    it("keeps a full URL untouched", () => {
+        expect(Validations.validateQuery({ query: "http://files.example/track.mp3", source: SearchSources.Youtube })).toBe(
+            "http://files.example/track.mp3",
+        );
+        expect(Validations.validateQuery({ query: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", source: SearchSources.Youtube })).toBe(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        );
+    });
+
+    it("builds an identifier for free text using the given source", () => {
+        expect(Validations.validateQuery({ query: "  never gonna give you up  ", source: SearchSources.Youtube })).toBe(
+            "ytsearch:never gonna give you up",
+        );
+    });
+
+    it("honours an explicit source prefix over the given source", () => {
+        expect(Validations.validateQuery({ query: "scsearch:some song", source: SearchSources.Youtube })).toBe("scsearch:some song");
+    });
+
+    it("unwraps a URL placed behind a source prefix", () => {
+        expect(Validations.validateQuery({ query: "spsearch:https://open.spotify.com/track/abc", source: SearchSources.Youtube })).toBe(
+            "https://open.spotify.com/track/abc",
+        );
+    });
+});
+
+describe("Validations.validateManagerOptions", () => {
+    it("rejects numeric manager options that are not non-negative integers", () => {
+        const cases: Partial<HoshimiOptions>[] = [
+            { queueOptions: { maxHistory: Number.NaN } },
+            { queueOptions: { maxHistory: -1 } },
+            { restOptions: { restTimeout: Number.NaN } },
+            { restOptions: { resumeTimeout: 1.5 } },
+            { nodeOptions: { heartbeatOptions: { interval: Number.NaN } } },
+            { nodeOptions: { sessionOptions: { timeout: Number.POSITIVE_INFINITY } } },
+        ];
+
+        for (const override of cases) {
+            expect(() => Validations.validateManagerOptions({ ...createOptions(), ...override })).toThrow(OptionError);
+        }
+    });
+
+    it("rejects numeric node options that are not non-negative integers", () => {
+        const nodes: NodeOptions[] = [
+            { host: "localhost", port: 0, password: "pass" },
+            { host: "localhost", port: 70000, password: "pass" },
+            { host: "localhost", port: 2333.5, password: "pass" },
+            { host: "localhost", port: Number.NaN, password: "pass" },
+            { host: "localhost", port: 2333, password: "pass", retryAmount: Number.NaN },
+            { host: "localhost", port: 2333, password: "pass", retryDelay: -1 },
+            { host: "localhost", port: 2333, password: "pass", restTimeout: Number.POSITIVE_INFINITY },
+            { host: "localhost", port: 2333, password: "pass", heartbeat: { interval: Number.NaN } },
+        ];
+
+        for (const node of nodes) {
+            expect(() => Validations.validateManagerOptions({ ...createOptions(), nodes: [node] })).toThrow(OptionError);
+        }
+    });
+
+    it("accepts valid numeric options", () => {
+        expect(() =>
+            Validations.validateManagerOptions({
+                ...createOptions(),
+                nodes: [{ host: "localhost", port: 443, password: "pass", retryAmount: 0, retryDelay: 20000 }],
+                queueOptions: { maxHistory: 0 },
+                restOptions: { restTimeout: 5000, resumeTimeout: 10000 },
+                nodeOptions: {
+                    sessionOptions: { timeout: 60 },
+                    heartbeatOptions: { interval: 0 },
+                },
+            }),
+        ).not.toThrow();
+    });
+});
+
+describe("Validations.validatePlayerOptions", () => {
+    it("rejects a non-finite or negative volume", () => {
+        for (const volume of [Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+            expect(() => Validations.validatePlayerOptions({ guildId: "guild-1", voiceId: "voice-1", volume })).toThrow(OptionError);
+        }
+    });
+
+    it("accepts a fractional volume, since setVolume rounds it", () => {
+        expect(() => Validations.validatePlayerOptions({ guildId: "guild-1", voiceId: "voice-1", volume: 50.5 })).not.toThrow();
+    });
+});

--- a/tests/filters/filter-plugins.test.ts
+++ b/tests/filters/filter-plugins.test.ts
@@ -5,19 +5,19 @@ import { FilterType } from "../../src/types/Filters";
 
 function createManagerMock() {
     return {
-        apply: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockResolvedValue(undefined),
     };
 }
 
 describe("Filter plugin facades", () => {
-    it("LavalinkPluginFilter.setEcho delegates to manager.apply with FilterType.Echo and the given payload", async () => {
+    it("LavalinkPluginFilter.setEcho delegates to manager.set with FilterType.Echo and the given payload", async () => {
         const manager = createManagerMock();
         const plugin = new LavalinkPluginFilter(manager as never);
 
         await plugin.setEcho({ decay: 0.5, delay: 200 });
 
-        expect(manager.apply).toHaveBeenCalledTimes(1);
-        expect(manager.apply).toHaveBeenCalledWith(FilterType.Echo, { decay: 0.5, delay: 200 });
+        expect(manager.set).toHaveBeenCalledTimes(1);
+        expect(manager.set).toHaveBeenCalledWith(FilterType.Echo, { decay: 0.5, delay: 200 });
     });
 
     it("LavalinkPluginFilter.setEcho applies preset defaults when called without args", async () => {
@@ -26,80 +26,80 @@ describe("Filter plugin facades", () => {
 
         await plugin.setEcho();
 
-        expect(manager.apply).toHaveBeenCalledWith(
+        expect(manager.set).toHaveBeenCalledWith(
             FilterType.Echo,
             expect.objectContaining({ decay: expect.any(Number), delay: expect.any(Number) }),
         );
     });
 
-    it("LavalinkPluginFilter.setReverb delegates to manager.apply with FilterType.Reverb", async () => {
+    it("LavalinkPluginFilter.setReverb delegates to manager.set with FilterType.Reverb", async () => {
         const manager = createManagerMock();
         const plugin = new LavalinkPluginFilter(manager as never);
 
         await plugin.setReverb({ delays: [50, 100], gains: [0.5, 0.3] });
 
-        expect(manager.apply).toHaveBeenCalledWith(FilterType.Reverb, {
+        expect(manager.set).toHaveBeenCalledWith(FilterType.Reverb, {
             delays: [50, 100],
             gains: [0.5, 0.3],
         });
     });
 
-    it("LavalinkPluginFilter.setEcho propagates errors from manager.apply", async () => {
+    it("LavalinkPluginFilter.setEcho propagates errors from manager.set", async () => {
         const manager = createManagerMock();
-        manager.apply.mockRejectedValueOnce(new Error("apply failed"));
+        manager.set.mockRejectedValueOnce(new Error("apply failed"));
         const plugin = new LavalinkPluginFilter(manager as never);
 
         await expect(plugin.setEcho()).rejects.toThrow("apply failed");
     });
 
-    it("DSPXPluginFilter.setLowPass delegates to manager.apply with FilterType.DSPXLowpass", async () => {
+    it("DSPXPluginFilter.setLowPass delegates to manager.set with FilterType.DSPXLowpass", async () => {
         const manager = createManagerMock();
         const dspx = new DSPXPluginFilter(manager as never);
 
         await dspx.setLowPass({ cutoffFrequency: 200, boostFactor: 1.2 });
 
-        expect(manager.apply).toHaveBeenCalledWith(FilterType.DSPXLowpass, {
+        expect(manager.set).toHaveBeenCalledWith(FilterType.DSPXLowpass, {
             cutoffFrequency: 200,
             boostFactor: 1.2,
         });
     });
 
-    it("DSPXPluginFilter.setHighPass delegates to manager.apply with FilterType.DSPXHighpass", async () => {
+    it("DSPXPluginFilter.setHighPass delegates to manager.set with FilterType.DSPXHighpass", async () => {
         const manager = createManagerMock();
         const dspx = new DSPXPluginFilter(manager as never);
 
         await dspx.setHighPass({ cutoffFrequency: 2000, boostFactor: 0.8 });
 
-        expect(manager.apply).toHaveBeenCalledWith(FilterType.DSPXHighpass, {
+        expect(manager.set).toHaveBeenCalledWith(FilterType.DSPXHighpass, {
             cutoffFrequency: 2000,
             boostFactor: 0.8,
         });
     });
 
-    it("DSPXPluginFilter.setNormalization delegates to manager.apply with FilterType.DSPXNormalization", async () => {
+    it("DSPXPluginFilter.setNormalization delegates to manager.set with FilterType.DSPXNormalization", async () => {
         const manager = createManagerMock();
         const dspx = new DSPXPluginFilter(manager as never);
 
         await dspx.setNormalization({ maxAmplitude: 0.9, adaptive: true });
 
-        expect(manager.apply).toHaveBeenCalledWith(
+        expect(manager.set).toHaveBeenCalledWith(
             FilterType.DSPXNormalization,
             expect.objectContaining({ maxAmplitude: 0.9, adaptive: true }),
         );
     });
 
-    it("DSPXPluginFilter.setEcho delegates to manager.apply with FilterType.DSPXEcho", async () => {
+    it("DSPXPluginFilter.setEcho delegates to manager.set with FilterType.DSPXEcho", async () => {
         const manager = createManagerMock();
         const dspx = new DSPXPluginFilter(manager as never);
 
         await dspx.setEcho({ decay: 0.5, echoLength: 0.5 });
 
-        expect(manager.apply).toHaveBeenCalledWith(FilterType.DSPXEcho, expect.objectContaining({ decay: 0.5, echoLength: 0.5 }));
+        expect(manager.set).toHaveBeenCalledWith(FilterType.DSPXEcho, expect.objectContaining({ decay: 0.5, echoLength: 0.5 }));
     });
 
-    it("DSPXPluginFilter.setLowPass propagates errors from manager.apply", async () => {
+    it("DSPXPluginFilter.setLowPass propagates errors from manager.set", async () => {
         const manager = createManagerMock();
-        manager.apply.mockRejectedValueOnce(new Error("apply failed"));
+        manager.set.mockRejectedValueOnce(new Error("apply failed"));
         const dspx = new DSPXPluginFilter(manager as never);
 
         await expect(dspx.setLowPass()).rejects.toThrow("apply failed");

--- a/tests/filters/filter-registry.test.ts
+++ b/tests/filters/filter-registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, type Mock } from "vitest";
-import { FilterRegistry, FilterScope } from "../../src/registry/FiltersRegistry";
+import { PlayerError } from "../../src/classes/Errors";
+import { defineFilter, FilterRegistry, FilterScope } from "../../src/registry/FiltersRegistry";
 import { PluginCapabilities } from "../../src/registry/PluginRegistry";
 import { AudioOutput, FilterType } from "../../src/types/Filters";
 import type { FilterManagerStructure } from "../../src/types/Structures";
@@ -90,6 +91,35 @@ describe("FilterRegistry echo disambiguation", () => {
     });
 });
 
+describe("FilterRegistry key classification", () => {
+    it("isPluginName only recognises plugins that own nested filters", () => {
+        expect(FilterRegistry.isPluginName("lavalink-filter-plugin")).toBe(true);
+
+        // Flat DSPX filters declare no pluginName, so their keys are filters, not envelopes.
+        expect(FilterRegistry.isPluginName("echo")).toBe(false);
+        expect(FilterRegistry.isPluginName("low-pass")).toBe(false);
+
+        // Never registered: a filter of its own.
+        expect(FilterRegistry.isPluginName("my-fork-plugin")).toBe(false);
+    });
+
+    it("isKnown separates unregistered names from unresolvable ones", () => {
+        expect(FilterRegistry.isKnown(FilterType.Echo)).toBe(true);
+        expect(FilterRegistry.isKnown(FilterType.DSPXEcho)).toBe(true);
+        expect(FilterRegistry.isKnown("myFilter")).toBe(false);
+
+        // Known, yet unresolvable on a node without the backing plugin.
+        expect(FilterRegistry.resolve(FilterType.Echo, fakeNode([], []))).toBeNull();
+        expect(FilterRegistry.isKnown(FilterType.Echo)).toBe(true);
+    });
+
+    it("defineFilter is a pass-through", () => {
+        const registration = { name: "passthrough", scope: FilterScope.Core };
+
+        expect(defineFilter(registration)).toBe(registration);
+    });
+});
+
 describe("FilterManager envelope routing", () => {
     it("dspx.setEcho writes a flat pluginFilters.echo payload and leaves the nested one untouched", async () => {
         const { fm } = bothPlugins();
@@ -98,7 +128,7 @@ describe("FilterManager envelope routing", () => {
 
         const pf = fm.data.pluginFilters as Record<string, Record<string, unknown>>;
         expect(pf.echo).toEqual({ echoLength: 0.5, decay: 0.5 });
-        expect(pf["lavalink-filter-plugin"].echo).toEqual({ delay: 0, decay: 0 });
+        expect(pf["lavalink-filter-plugin"]).toBeUndefined(); // the nested envelope is never created
     });
 
     it("plugin.setEcho writes a nested pluginFilters['lavalink-filter-plugin'].echo payload", async () => {
@@ -107,8 +137,8 @@ describe("FilterManager envelope routing", () => {
         await fm.plugin.setEcho({ delay: 4, decay: 0.8 });
 
         const pf = fm.data.pluginFilters as Record<string, Record<string, unknown>>;
-        expect(pf["lavalink-filter-plugin"].echo).toEqual({ delay: 4, decay: 0.8 });
-        expect(pf.echo).toEqual({ decay: 0, delay: 0, echoLength: 0 }); // flat dspx echo untouched
+        expect(pf["lavalink-filter-plugin"]!.echo).toEqual({ delay: 4, decay: 0.8 });
+        expect(pf.echo).toBeUndefined(); // the flat dspx echo is never created
     });
 
     it("dspx.setLowPass sends exactly the flat DSPX low-pass envelope", async () => {
@@ -131,10 +161,10 @@ describe("FilterManager envelope routing", () => {
         });
     });
 
-    it("commit keeps a dspx echo that only sets echoLength (uses the dspx default predicate)", async () => {
+    it("commit keeps a dspx echo whose decay is 0", async () => {
         const { fm, spy } = bothPlugins();
 
-        // decay 0 but echoLength set: with the filter-plugin predicate this would be wrongly stripped.
+        // Presence is what activates a filter, so a zero member does not make the payload disappear.
         await fm.dspx.setEcho({ echoLength: 0.5, decay: 0 });
 
         expect(sentFilters(spy)).toEqual({ pluginFilters: { echo: { echoLength: 0.5, decay: 0 } } });
@@ -196,16 +226,17 @@ describe("FilterManager combined / clear / reset semantics", () => {
     });
 });
 
-describe("FilterManager default-state stripping", () => {
+describe("FilterManager presence semantics", () => {
     it("a fresh commit sends a completely empty filters payload", async () => {
         const { fm, spy } = bothPlugins();
 
-        await fm.apply(); // no-arg commit with fresh defaults
+        await fm.apply(); // no-arg commit on an untouched payload
 
+        expect(fm.data).toEqual({});
         expect(sentFilters(spy)).toEqual({});
     });
 
-    it("regression: applying a single filter never leaks default karaoke/distortion/pluginFilters", async () => {
+    it("applying a single filter sends only that key", async () => {
         const { fm, spy } = setup();
 
         await fm.setNightcore();
@@ -217,25 +248,181 @@ describe("FilterManager default-state stripping", () => {
         expect(Object.keys(filters)).toEqual(["timescale"]);
     });
 
-    it("keeps a distortion that is not the identity transform", async () => {
+    it("sends an all-zero payload, since presence is what activates a filter", async () => {
         const { fm, spy } = setup();
 
-        await fm.setDistortion({ scale: 2 });
+        await fm.setKaraoke({ level: 0, monoLevel: 0, filterBand: 0, filterWidth: 0 });
 
-        expect(sentFilters(spy)).toEqual({ distortion: { scale: 2 } });
+        expect(sentFilters(spy)).toEqual({ karaoke: { level: 0, monoLevel: 0, filterBand: 0, filterWidth: 0 } });
+        expect(fm.isEnabled(FilterType.Karaoke)).toBe(true);
     });
 
-    it("keeps a karaoke where a single parameter is non-zero", async () => {
+    it("isEnabled tracks presence, not payload values", async () => {
+        const { fm } = setup();
+
+        expect(fm.isEnabled(FilterType.Volume)).toBe(false);
+
+        await fm.setVolume(1); // the old neutral volume: active now that it was set explicitly
+
+        expect(fm.isEnabled(FilterType.Volume)).toBe(true);
+    });
+
+    it("get returns the active payload, and undefined once cleared", async () => {
+        const { fm } = setup();
+
+        expect(fm.get(FilterType.Timescale)).toBeUndefined();
+
+        await fm.setNightcore();
+        expect(fm.get(FilterType.Timescale)).toEqual({ ...DefaultFilterPreset.Nightcore });
+
+        await fm.clear(FilterType.Timescale);
+        expect(fm.get(FilterType.Timescale)).toBeUndefined();
+    });
+
+    it("get reads from the envelope the routing options point at", async () => {
+        const { fm } = setup();
+
+        await fm.set("boost", { gain: 2 }, { plugin: "my-plugin" });
+
+        expect(fm.get("boost", { plugin: "my-plugin" })).toEqual({ gain: 2 });
+        expect(fm.get("boost")).toBeUndefined(); // flat envelope, nothing there
+    });
+
+    it("clear() removes the key instead of neutralising it", async () => {
         const { fm, spy } = setup();
 
-        await fm.setKaraoke({ level: 0.5 });
+        await fm.setNightcore();
+        expect(fm.isEnabled(FilterType.Timescale)).toBe(true);
 
-        expect(sentFilters(spy)).toEqual({ karaoke: { level: 0.5, monoLevel: 0, filterBand: 0, filterWidth: 0 } });
+        await fm.clear(FilterType.Timescale);
+
+        expect(fm.isEnabled(FilterType.Timescale)).toBe(false);
+        expect(fm.data.timescale).toBeUndefined();
+        expect(sentFilters(spy)).toEqual({});
+    });
+
+    it("clearEQBands removes the equalizer key", async () => {
+        const { fm, spy } = setup();
+
+        await fm.setEQBand({ band: 0, gain: 0.25 });
+        expect(fm.isEnabled(FilterType.Equalizer)).toBe(true);
+
+        await fm.clearEQBands();
+
+        expect(fm.data.equalizer).toBeUndefined();
+        expect(fm.isEnabled(FilterType.Equalizer)).toBe(false);
+        expect(sentFilters(spy)).toEqual({});
     });
 });
 
-describe("FilterManager player isolation (no shared default state)", () => {
-    it("does not share pluginFilters objects between players and does not leak mutations", async () => {
+describe("FilterManager.set with unregistered filters", () => {
+    it("routes an unknown filter to a flat pluginFilters entry", async () => {
+        const { fm, spy } = setup();
+
+        await fm.set("myFilter", { gain: 2 });
+
+        expect(sentFilters(spy)).toEqual({ pluginFilters: { myFilter: { gain: 2 } } });
+        expect(fm.isEnabled("myFilter")).toBe(true);
+    });
+
+    it("nests an unknown filter under the given plugin", async () => {
+        const { fm, spy } = setup();
+
+        await fm.set("boost", { gain: 2 }, { plugin: "my-fork-plugin" });
+
+        expect(sentFilters(spy)).toEqual({ pluginFilters: { "my-fork-plugin": { boost: { gain: 2 } } } });
+        expect(fm.isEnabled("boost", { plugin: "my-fork-plugin" })).toBe(true);
+        expect(fm.isEnabled("boost")).toBe(false); // not the flat envelope
+    });
+
+    it("writes an unknown filter at the top level with top: true and keeps it through commit", async () => {
+        const { fm, spy } = setup();
+
+        // The node advertises none of this: an unknown top-level key must survive anyway.
+        await fm.set("forkEcho", { decay: 0.5 }, { top: true });
+
+        expect(sentFilters(spy)).toEqual({ forkEcho: { decay: 0.5 } });
+        expect(fm.isEnabled("forkEcho", { top: true })).toBe(true);
+    });
+
+    it("clears an unknown filter from the envelope it was written to", async () => {
+        const { fm, spy } = setup();
+
+        await fm.set("boost", { gain: 2 }, { plugin: "my-fork-plugin" });
+        await fm.clear("boost", { plugin: "my-fork-plugin" });
+
+        expect(sentFilters(spy)).toEqual({});
+        expect(fm.data.pluginFilters).toBeUndefined(); // empty wrapper pruned
+    });
+
+    it("keeps registered and unregistered filters side by side", async () => {
+        const { fm, spy } = setup();
+
+        await fm.setNightcore();
+        await fm.set("myFilter", { gain: 2 });
+        await fm.set("forkEcho", { decay: 0.5 }, { top: true });
+
+        expect(sentFilters(spy)).toEqual({
+            timescale: { ...DefaultFilterPreset.Nightcore },
+            forkEcho: { decay: 0.5 },
+            pluginFilters: { myFilter: { gain: 2 } },
+        });
+    });
+
+    it("rejects contradictory routing options", async () => {
+        const { fm } = setup();
+
+        await expect(fm.set("x", {}, { plugin: true, top: true })).rejects.toThrow(PlayerError);
+    });
+
+    it("skips node validation for unknown filters, but honours validate: true", async () => {
+        const { fm, spy } = setup({ filters: [...BUILTIN_FILTERS, "advertisedFork"] });
+
+        // Not advertised, no validation asked for: goes through.
+        await expect(fm.set("myFilter", { gain: 2 })).resolves.toBe(fm);
+
+        // Not advertised and validation asked for: refused.
+        await expect(fm.set("ghost", { gain: 2 }, { validate: true })).rejects.toThrow(PlayerError);
+
+        // Advertised and validation asked for: goes through.
+        spy.mockClear();
+        await fm.set("advertisedFork", { gain: 1 }, { top: true, validate: true });
+        expect(sentFilters(spy)).toHaveProperty("advertisedFork");
+    });
+
+    it("lets an explicit envelope override what the registry resolved", async () => {
+        const { fm, spy } = bothPlugins();
+
+        // FilterType.Echo normally nests under lavalink-filter-plugin.
+        await fm.set(FilterType.Echo, { delay: 4, decay: 0.8 }, { top: true });
+
+        expect(sentFilters(spy)).toEqual({ echo: { delay: 4, decay: 0.8 } });
+    });
+
+    it("validates registered filters unless validate: false", async () => {
+        const { fm, spy } = setup({ filters: ["volume"] }); // timescale not advertised
+
+        await expect(fm.setNightcore()).rejects.toThrow();
+
+        spy.mockClear();
+        await fm.set(FilterType.Timescale, { speed: 1.2, pitch: 1, rate: 1 }, { validate: false });
+
+        // Written, but commit still drops a registered filter the node does not advertise.
+        expect(fm.data.timescale).toEqual({ speed: 1.2, pitch: 1, rate: 1 });
+        expect(sentFilters(spy)).toEqual({});
+    });
+
+    it("apply(name, payload) still works as a deprecated alias of set", async () => {
+        const { fm, spy } = setup();
+
+        await fm.apply(FilterType.Volume, 2);
+
+        expect(sentFilters(spy)).toEqual({ volume: 2 });
+    });
+});
+
+describe("FilterManager player isolation", () => {
+    it("does not leak payload writes between players", async () => {
         const manager = createRealManager();
         const node = createRealNode(manager);
         node.info = {
@@ -247,12 +434,14 @@ describe("FilterManager player isolation (no shared default state)", () => {
         const a = createRealPlayer(manager, { guildId: "g-a", voiceId: "v-a" });
         const b = createRealPlayer(manager, { guildId: "g-b", voiceId: "v-b" });
 
-        expect(a.filterManager.data.pluginFilters).not.toBe(b.filterManager.data.pluginFilters);
+        expect(a.filterManager.data).not.toBe(b.filterManager.data);
+        expect(a.filterManager.data).toEqual({});
+        expect(b.filterManager.data).toEqual({});
 
         await a.filterManager.dspx.setEcho({ echoLength: 0.5, decay: 0.5 });
 
-        const bpf = b.filterManager.data.pluginFilters as Record<string, unknown>;
-        expect(bpf.echo).toEqual({ decay: 0, delay: 0, echoLength: 0 }); // still default, not leaked from A
+        expect((a.filterManager.data.pluginFilters as Record<string, unknown>).echo).toEqual({ echoLength: 0.5, decay: 0.5 });
+        expect(b.filterManager.data).toEqual({}); // nothing created on B
     });
 });
 
@@ -272,5 +461,34 @@ describe("FilterManager capability pruning on commit", () => {
         await fm.apply(); // no-arg commit
 
         expect(sentFilters(spy)).toEqual({ pluginFilters: { echo: { echoLength: 0.5, decay: 0.5 } } });
+    });
+
+    it("keeps top-level filters when the node has not reported its info yet", async () => {
+        const { node, fm, spy } = setup();
+
+        fm.data.timescale = { speed: 1.29, pitch: 1.29, rate: 0.94 };
+        fm.data.rotation = { rotationHz: 0.2 };
+
+        // Not ready yet: no /v4/info response, so the advertised list is unknown, not empty.
+        node.info = null;
+        spy.mockClear();
+
+        await fm.apply();
+
+        expect(sentFilters(spy)).toEqual({
+            timescale: { speed: 1.29, pitch: 1.29, rate: 0.94 },
+            rotation: { rotationHz: 0.2 },
+        });
+    });
+
+    it("still drops top-level filters the node reports it does not support", async () => {
+        const { fm, spy } = setup({ filters: ["volume", "equalizer"] });
+
+        fm.data.timescale = { speed: 1.29, pitch: 1.29, rate: 0.94 };
+        spy.mockClear();
+
+        await fm.apply();
+
+        expect(sentFilters(spy)).toEqual({});
     });
 });

--- a/tests/node/heartbeat.test.ts
+++ b/tests/node/heartbeat.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { clearHeartbeatTimer, onPong, startHeartbeat } from "../../src/util/events/websocket";
+
+function createFakeNode(interval: number = 30000) {
+    const ws = { readyState: 1, terminate: vi.fn(), ping: vi.fn() };
+
+    const node = {
+        id: "node-1",
+        ws,
+        isAlive: true,
+        heartbeatInterval: null as NodeJS.Timeout | null,
+        options: { heartbeat: { interval } },
+        nodeManager: { manager: { debug: vi.fn() } },
+    };
+
+    return { node, ws };
+}
+
+describe("heartbeat ping/pong", () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("pings on every interval and terminates when no pong answers", () => {
+        vi.useFakeTimers();
+        const { node, ws } = createFakeNode(1000);
+
+        startHeartbeat.call(node as never);
+
+        vi.advanceTimersByTime(1000);
+        expect(ws.ping).toHaveBeenCalledTimes(1);
+        expect(node.isAlive).toBe(false);
+
+        onPong.call(node as never);
+        expect(node.isAlive).toBe(true);
+
+        vi.advanceTimersByTime(1000);
+        expect(ws.ping).toHaveBeenCalledTimes(2);
+
+        vi.advanceTimersByTime(1000);
+        expect(ws.terminate).toHaveBeenCalledTimes(1);
+    });
+
+    it("stays disabled when the interval is 0", () => {
+        vi.useFakeTimers();
+        const { node, ws } = createFakeNode(0);
+
+        startHeartbeat.call(node as never);
+
+        expect(node.heartbeatInterval).toBeNull();
+
+        vi.advanceTimersByTime(600000);
+        expect(ws.ping).not.toHaveBeenCalled();
+    });
+
+    it("clearHeartbeatTimer stops the interval", () => {
+        vi.useFakeTimers();
+        const { node, ws } = createFakeNode(1000);
+
+        startHeartbeat.call(node as never);
+        expect(node.heartbeatInterval).not.toBeNull();
+
+        clearHeartbeatTimer.call(node as never);
+        expect(node.heartbeatInterval).toBeNull();
+
+        vi.advanceTimersByTime(10000);
+        expect(ws.ping).not.toHaveBeenCalled();
+        expect(ws.terminate).not.toHaveBeenCalled();
+    });
+});

--- a/tests/node/node.test.ts
+++ b/tests/node/node.test.ts
@@ -68,7 +68,6 @@ function createNode(client?: { id?: string; username?: string }) {
                     },
                     heartbeatOptions: {
                         interval: 30000,
-                        statsTimeout: 65000,
                     },
                 },
                 restOptions: {
@@ -159,7 +158,7 @@ describe("Node", () => {
         node.connect();
 
         const instances = WebSocket as unknown as { instances: Array<Record<string, unknown>> };
-        const ws = instances.instances[0];
+        const ws = instances.instances[0]!;
 
         expect(node.state).toBe(State.Connecting);
         expect(ws.url).toBe("ws://localhost:2333/v4/websocket");
@@ -190,7 +189,7 @@ describe("Node", () => {
         node.connect();
 
         const instances = WebSocket as unknown as { OPEN: number; instances: Array<{ readyState: number }> };
-        instances.instances[0].readyState = instances.OPEN;
+        instances.instances[0]!.readyState = instances.OPEN;
 
         expect(node.ready).toBe(true);
     });
@@ -242,7 +241,7 @@ describe("Node", () => {
         node.disconnect({ code: 1000, reason: "bye" });
 
         const instances = WebSocket as unknown as { instances: Array<{ closedWith: { code?: number; reason?: string } }> };
-        const ws = instances.instances[0];
+        const ws = instances.instances[0]!;
 
         expect(ws.closedWith).toEqual({ code: 1000, reason: "bye" });
         expect(node.ws).toBeNull();

--- a/tests/node/rest.test.ts
+++ b/tests/node/rest.test.ts
@@ -56,6 +56,34 @@ describe("Rest", () => {
         expect(opts.headers["User-Agent"]).toContain("hoshimi-test");
     });
 
+    it("request censors the password in the debug log", async () => {
+        const manager = createRealManager();
+        const node = createRealNode(manager);
+        node.sessionId = "sess-123";
+        const rest = new Rest(node as never);
+
+        (node.rest.request as ReturnType<typeof vi.fn>).mockRestore();
+
+        const debugSpy = vi.spyOn(manager, "debug");
+
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue({
+                ok: true,
+                status: HttpStatusCodes.OK,
+                json: vi.fn().mockResolvedValue({}),
+            } as never),
+        );
+
+        await rest.request({ endpoint: RestRoutes.NodeInfo });
+
+        const logged = debugSpy.mock.calls.map(([, message]) => message).join("\n");
+
+        expect(logged).toContain("Headers:");
+        expect(logged).not.toContain("pass");
+        expect(logged).toContain('"Authorization":"****"');
+    });
+
     it("request sends POST body as string", async () => {
         const manager = createRealManager();
         const node = createRealNode(manager);

--- a/tests/player/player-onerror.test.ts
+++ b/tests/player/player-onerror.test.ts
@@ -25,7 +25,7 @@ const endPayload = (guildId: string) =>
 describe("Player onError", () => {
     it("autoDestroy destroys the player on track error", async () => {
         const manager = createRealManager({ playerOptions: { onError: { autoDestroy: true } } });
-        const { trackError } = await import("../../src/util/events/player");
+        const { trackError } = await import("../../src/util/events/player.js");
         const player = createRealPlayer(manager);
 
         const destroySpy = vi.spyOn(player, "destroy").mockResolvedValue();
@@ -37,7 +37,7 @@ describe("Player onError", () => {
 
     it("autoStop halts playback and suppresses the trailing track end", async () => {
         const manager = createRealManager({ playerOptions: { onError: { autoStop: true } } });
-        const { trackEnd, trackError } = await import("../../src/util/events/player");
+        const { trackEnd, trackError } = await import("../../src/util/events/player.js");
         const player = createRealPlayer(manager);
 
         player.playing = true;
@@ -61,7 +61,7 @@ describe("Player onError", () => {
 
     it("default behaviour neither destroys nor stops the player", async () => {
         const manager = createRealManager();
-        const { trackError } = await import("../../src/util/events/player");
+        const { trackError } = await import("../../src/util/events/player.js");
         const player = createRealPlayer(manager);
 
         const destroySpy = vi.spyOn(player, "destroy").mockResolvedValue();

--- a/tests/player/player.test.ts
+++ b/tests/player/player.test.ts
@@ -32,6 +32,30 @@ describe("Player", () => {
         await expect(player.setVolume(NaN)).rejects.toThrow(PlayerError);
     });
 
+    it("skip throws on an empty queue, or resolves when throwError is false", async () => {
+        const manager = createRealManager();
+        const node = createRealNode(manager);
+        const player = createRealPlayer(manager);
+
+        await expect(player.skip()).rejects.toThrow(PlayerError);
+
+        await expect(player.skip({ throwError: false })).resolves.toBeUndefined();
+        expect(node.rest.stopPlayer).not.toHaveBeenCalled();
+    });
+
+    it("skip stops playback when a track is playing", async () => {
+        const manager = createRealManager();
+        const node = createRealNode(manager);
+        const player = createRealPlayer(manager);
+
+        player.playing = true;
+        player.paused = false;
+
+        await player.skip({ throwError: false });
+
+        expect(node.rest.stopPlayer).toHaveBeenCalledWith(player.guildId);
+    });
+
     it("move throws when target node is missing", async () => {
         const manager = createRealManager();
         createRealNode(manager);

--- a/tests/queue/queue.test.ts
+++ b/tests/queue/queue.test.ts
@@ -65,7 +65,73 @@ describe("Queue", () => {
         expect(queue.tracks).toEqual(snapshot);
     });
 
-    it("toJSON trims history to maxHistory", () => {
+    it("move places the track at the given position", async () => {
+        const manager = createRealManager();
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+        const queue = player.queue;
+        vi.spyOn(queue.utils, "save").mockImplementation(() => undefined);
+
+        const [a, b, c] = [mockedTrack("a"), mockedTrack("b"), mockedTrack("c")];
+        await queue.add([a, b, c] as never);
+
+        await queue.move(c as never, 0);
+        expect(queue.tracks.map((track) => track.encoded)).toEqual(["c", "a", "b"]);
+
+        await queue.move(c as never, 1);
+        expect(queue.tracks.map((track) => track.encoded)).toEqual(["a", "c", "b"]);
+    });
+
+    it("move clamps an out of range position", async () => {
+        const manager = createRealManager();
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+        const queue = player.queue;
+        vi.spyOn(queue.utils, "save").mockImplementation(() => undefined);
+
+        const [a, b, c] = [mockedTrack("a"), mockedTrack("b"), mockedTrack("c")];
+        await queue.add([a, b, c] as never);
+
+        await queue.move(a as never, 99);
+        expect(queue.tracks.map((track) => track.encoded)).toEqual(["b", "c", "a"]);
+
+        await queue.move(a as never, -5);
+        expect(queue.tracks.map((track) => track.encoded)).toEqual(["a", "b", "c"]);
+    });
+
+    it("move persists and notifies exactly once", async () => {
+        const manager = createRealManager();
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+        const queue = player.queue;
+
+        const save = vi.spyOn(queue.utils, "save").mockImplementation(() => undefined);
+
+        const [a, b] = [mockedTrack("a"), mockedTrack("b")];
+        await queue.add([a, b] as never);
+
+        const emit = vi.spyOn(manager, "emit");
+        save.mockClear();
+
+        await queue.move(b as never, 0);
+
+        expect(save).toHaveBeenCalledTimes(1);
+        expect(emit.mock.calls.filter(([event]) => event === "queueUpdate")).toHaveLength(1);
+    });
+
+    it("splice inserts into an empty queue without duplicating", async () => {
+        const manager = createRealManager();
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+        const queue = player.queue;
+        vi.spyOn(queue.utils, "save").mockImplementation(() => undefined);
+
+        await queue.splice(0, 0, mockedTrack("a") as never);
+
+        expect(queue.tracks.map((track) => track.encoded)).toEqual(["a"]);
+    });
+
+    it("toJSON trims history to maxHistory without mutating it", () => {
         const manager = createRealManager({ queueOptions: { maxHistory: 2 } } as never);
         createRealNode(manager);
         const player = createRealPlayer(manager);
@@ -75,6 +141,7 @@ describe("Queue", () => {
         const json = queue.toJSON();
 
         expect(json.history.length).toBe(2);
+        expect(queue.history.length).toBe(3);
     });
 });
 
@@ -146,6 +213,18 @@ describe("QueueUtils", () => {
         const player = createRealPlayer(manager);
         const queue = player.queue;
 
+        queue.tracks.push({ encoded: "track" } as TrackResolvableStructure);
+
+        expect(() => queue.toJSON()).toThrow(QueueError);
+    });
+
+    it("throws when only some tracks are invalid", () => {
+        const manager = createRealManager();
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+        const queue = player.queue;
+
+        queue.tracks.push(mockedTrack("valid"));
         queue.tracks.push({ encoded: "track" } as TrackResolvableStructure);
 
         expect(() => queue.toJSON()).toThrow(QueueError);

--- a/tests/storage/storage.test.ts
+++ b/tests/storage/storage.test.ts
@@ -17,8 +17,9 @@ describe("storage", () => {
         storage.set(key, value);
 
         expect(storage.has(key)).toBe(true);
-        expect(storage.get(key)).toBeUndefined();
-        expect(storage.get(namespacedKey)).toEqual(value);
+        expect(storage.get(key)).toEqual(value);
+        expect(storage.get(namespacedKey)).toBeUndefined();
+        expect(storage.get("unknown-guild")).toBeUndefined();
 
         expect(storage.delete(key)).toBe(true);
         expect(storage.has(key)).toBe(false);
@@ -53,5 +54,19 @@ describe("storage", () => {
 
         storage.clear();
         expect(storage.size()).toBe(0);
+    });
+
+    it("PlayerMemoryStorage hides internal keys from every enumeration", () => {
+        const storage = new PlayerMemoryStorage("guild-1");
+
+        storage.set("volume" as never, 100 as never);
+        storage.set("internal_stopPlaying" as never, true as never);
+
+        expect(storage.get("internal_stopPlaying" as never)).toBe(true);
+
+        expect(storage.keys()).toEqual(["volume"]);
+        expect(storage.values()).toEqual([100]);
+        expect(storage.entries()).toEqual([["volume", 100]]);
+        expect(storage.all()).toEqual({ volume: 100 });
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,6 @@
 {
     /* from https://github.com/total-typescript/tsconfig - bundler/no-dom/app */
     "compilerOptions": {
-        "rootDir": "src",
-        "outDir": "dist",
-
         /* Base Options: */
         "esModuleInterop": true,
         "skipLibCheck": true,
@@ -31,6 +28,6 @@
         /* If your code doesn't run in the DOM: */
         "lib": ["es2022"]
     },
-    "include": ["src"],
+    "include": ["src", "tests"],
     "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
release v0.5.0

Ships the audit + filter API work merged in #23. Minor bump with breaking changes; `changeset status` plans `0.4.0 -> 0.5.0`.

Merging this only triggers `release.yml`: the changesets action opens `chore: release packages`, which applies the bump, writes `CHANGELOG.md` and consumes the two changesets. **Publishing happens when that second PR is merged**, not this one.

## What ships

**Filters — breaking.** A filter is active by the presence of its key; the neutral-payload model and its `isDefault` predicates are gone. New `set(name, payload, options?)` writes any filter, registered or not, choosing the envelope (`pluginFilters`, nested under a plugin, or top level). New `get()`, typed per filter like `set` — `set(FilterType.Volume, { nope: true })` no longer compiles. Also removed: `DefaultPlayerFilters`, `FilterScope.Vendor` and the vendor machinery, `FilterType.AudioOutput`/`Custom`, and half of `FilterRegistry`.

**16 audit fixes.** Most consequential: a `VOICE_STATE_UPDATE` from any other guild member overwrote the player's session id (Lavalink 4006); `QueueMemoryStorage.get()` never found anything, which silently broke `resumeByLibrary`; `splice()` duplicated tracks inserted into an empty queue; the REST layer logged the node password on every request.

**`heartbeat.statsTimeout` removed** — documented as a stats watchdog, but no timer was ever armed.

**Tooling.** CI now runs the suite (191 -> 233 tests) before pushing, publishing or releasing — `dev.yml` was publishing to npm untested. The changesets flow itself was broken: `pnpm-workspace.yaml` declared `packages: []`, so no changeset could ever resolve `hoshimi`.

Full detail in the two changesets and in #23.

## After publishing

Bump `hoshimi` to `0.5.0` in the docs site, which currently pins `0.4.1-dev-30661944975.0`.