### PR TITLE
ci: publish from the release branch without a version pull request

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,6 +41,9 @@ jobs:
   linter:
     # Nothing gets pushed back or published off a red test run.
     needs: test
+    # Push events only: this job commits back to `github.ref`, which on a pull_request is the ephemeral
+    # `refs/pull/N/merge` — not a branch to push to, and gone the moment the pull request is merged.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
         contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'Ganyu-Studios/Hoshimi'
     permissions:
-      # id-token for npm provenance; the other two are what changesets/action needs to push
-      # `changeset-release/release` and open the version pull request. Declaring any permissions
-      # block sets every unlisted scope to none, which is why omitting them returned a 403.
+      # id-token for npm provenance, contents to push the version commit back to `release`.
+      # Declaring any permissions block sets every unlisted scope to none.
       id-token: write
       contents: write
-      pull-requests: write
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -39,12 +37,36 @@ jobs:
       - name: Run tests
         run: pnpm test
 
-      - name: Create Release Pull Request
-        uses: changesets/action@v1
+      # Merging into `release` *is* the approval, so the version is applied and published here rather
+      # than through a second pull request on a `changeset-release/*` branch.
+      - name: Apply changesets
+        run: |
+          pnpm changeset version
+
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_ENV"
+
+          if npm view "hoshimi@$version" version > /dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_ENV"
+            echo "hoshimi@$version is already published, nothing to do."
+          else
+            echo "published=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Publish to npm
+        if: env.published == 'false'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        with:
-          commit: "chore: release packages"
-          publish: npm publish --provenance
-          title: "chore: release packages"
+        run: |
+          echo "Publishing hoshimi@$version"
+          npm config set //registry.npmjs.org/:_authToken ${NODE_AUTH_TOKEN}
+          npm publish --provenance
+
+      - name: Commit the release
+        if: env.published == 'false'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m "chore(release): v$version [skip ci]"
+          git push origin HEAD:release


### PR DESCRIPTION
Merging into `release` is already the approval, so the second pull request on `changeset-release/release` was duplicated ceremony. The job now runs `changeset version` itself, publishes when that version is not on npm yet, and pushes the bump back to `release`. `pull-requests: write` is no longer needed.

Also stops the linter job from running on pull_request events. It commits back to `github.ref`, which on a pull request is the ephemeral `refs/pull/N/merge`: not a branch to push to, and deleted the moment the pull request merges — which is exactly how it failed on #25, now that `needs: test` delays it long enough for the merge to land first.