### PR TITLE
feat: type the manager's events through a map

### DIFF
--- a/src/classes/Hoshimi.ts
+++ b/src/classes/Hoshimi.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from "node:events";
 import {
     type ChannelDelete,
     type ChannelDeletePacket,
@@ -20,6 +19,7 @@ import { type LavalinkPlayerVoice, type PlayerOptions, PlayerScope } from "../ty
 import { type NodeManagerStructure, type NodeStructure, type PlayerStructure, Structures, type TrackStructure } from "../types/Structures";
 import { Collection } from "../util/collection";
 import { HoshimiDefaultOptions } from "../util/constants";
+import { TypedEmitter } from "../util/emitter";
 import { isPlainObject, isPlayerGone, mergeDefault, stringify } from "../util/functions/utils";
 import { Validations } from "../util/functions/validations";
 import { ManagerError, OptionError } from "./Errors";
@@ -32,7 +32,7 @@ type GatewayPackets = VoicePacket | VoiceServer | VoiceState | ChannelDeletePack
 /**
  * Class representing the Hoshimi manager.
  * @class Hoshimi
- * @extends {EventEmitter<HoshimiEvents>}
+ * @extends {TypedEmitter<HoshimiEvents>}
  * @example
  * ```ts
  * import { Hoshimi, SearchSources } from "hoshimi";
@@ -65,7 +65,7 @@ type GatewayPackets = VoicePacket | VoiceServer | VoiceState | ChannelDeletePack
  * console.log(manager); // The manager instance
  * ```
  */
-export class Hoshimi extends EventEmitter<HoshimiEvents> {
+export class Hoshimi extends TypedEmitter<HoshimiEvents> {
     /**
      * The options for the manager.
      * @type {HoshimiOptions}

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,5 +46,9 @@ export * from "./types/Structures";
 // Exports related to constants.
 export * from "./util/constants";
 
+// Exports related to the typed event emitter. Part of the public surface because `Hoshimi` extends
+// it: without this, a consumer's `Hoshimi` type would reference a name they cannot resolve.
+export * from "./util/emitter";
+
 // Exports related to track utilities.
 export { TrackResolution } from "./util/functions/track";

--- a/src/util/emitter.ts
+++ b/src/util/emitter.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from "node:events";
+
+/**
+ * The shape an event map has to satisfy.
+ *
+ * The constraint is written in terms of the map's own keys rather than as an index signature
+ * (`{ [event: string]: unknown[] }`) because interfaces never get an implicit index signature and so
+ * would not satisfy the latter. Requiring a `type` alias instead would cost module augmentation,
+ * which is how a consumer adds their own events, so the self-referential form is the one that keeps
+ * a closed, augmentable interface usable.
+ * @example
+ * ```ts
+ * interface MyEvents {
+ * 	ready: [at: number];
+ * }
+ * ```
+ */
+export type EventMap<T> = Record<keyof T, unknown[]>;
+
+/**
+ * The event names of a map: whatever it declares, as long as the name is something an emitter can
+ * actually key on.
+ *
+ * The intersection is load-bearing, not decoration. The merged interface below has to stay
+ * compatible with the inherited `EventEmitter`, whose methods take `eventName: string | symbol`. A
+ * bare `keyof T` could include `number`, which is not assignable to that, and the whole class fails
+ * with TS2430 — "Interface 'TypedEmitter<T>' incorrectly extends interface 'EventEmitter<any>'".
+ *
+ * Note this is nothing like the open `string | symbol` union Node's own types use for event names.
+ * That one accepts anything; this one only keeps the names the map declares, so a symbol it never
+ * mentions is still rejected.
+ */
+export type EventKey<T> = keyof T & (string | symbol);
+
+/**
+ * The handler of a single event, with its parameters taken from the map's tuple. Named tuple members
+ * carry over, so `[player: Player, track: Track | null]` shows those names as parameter hints.
+ */
+export type EventListener<T extends EventMap<T>, K extends EventKey<T>> = (...args: T[K]) => void;
+
+/**
+ * The emitter surface, declared in full.
+ *
+ * Every method is listed on purpose. Redeclaring only some of them leaves the rest resolving to the
+ * inherited signature, which accepts any string and hands the listener `any` arguments — Node types
+ * `on` as `on<E extends string | symbol>(event: EventNames<T, E>, ...)`, and `EventNames` includes
+ * the inferred `E` itself, so nothing is ever rejected.
+ */
+export interface TypedEmitter<T extends EventMap<T>> {
+    on<K extends EventKey<T>>(event: K, listener: EventListener<T, K>): this;
+    once<K extends EventKey<T>>(event: K, listener: EventListener<T, K>): this;
+    off<K extends EventKey<T>>(event: K, listener: EventListener<T, K>): this;
+    addListener<K extends EventKey<T>>(event: K, listener: EventListener<T, K>): this;
+    removeListener<K extends EventKey<T>>(event: K, listener: EventListener<T, K>): this;
+    prependListener<K extends EventKey<T>>(event: K, listener: EventListener<T, K>): this;
+    prependOnceListener<K extends EventKey<T>>(event: K, listener: EventListener<T, K>): this;
+    removeAllListeners(event?: EventKey<T>): this;
+
+    emit<K extends EventKey<T>>(event: K, ...args: T[K]): boolean;
+
+    listeners<K extends EventKey<T>>(event: K): EventListener<T, K>[];
+    rawListeners<K extends EventKey<T>>(event: K): EventListener<T, K>[];
+    listenerCount<K extends EventKey<T>>(event: K, listener?: EventListener<T, K>): number;
+    eventNames(): EventKey<T>[];
+
+    getMaxListeners(): number;
+    setMaxListeners(count: number): this;
+}
+
+/**
+ * An {@link EventEmitter} whose events are described by a map, so an unknown name is a compile
+ * error and a handler's parameters are inferred instead of being `any`.
+ *
+ * The runtime is Node's emitter untouched — the class body is empty and the merged interface only
+ * describes it — so listener ordering, `once` removal and `instanceof` all behave exactly as before.
+ *
+ * The interface merges into the class rather than the methods being redeclared as `declare` fields:
+ * fields would type them as properties, and a subclass overriding `on` with ordinary method syntax
+ * would then fail with TS2425, losing access to `super.on` as well.
+ * @example
+ * ```ts
+ * interface MyEvents {
+ * 	ready: [at: number];
+ * }
+ *
+ * class MyThing extends TypedEmitter<MyEvents> {}
+ *
+ * const thing = new MyThing();
+ *
+ * thing.on("ready", (at) => console.log(at)); // `at` is a number
+ * thing.emit("ready", Date.now());
+ * ```
+ */
+// biome-ignore lint/suspicious/noUnsafeDeclarationMerging: the merge is the mechanism, see above.
+// biome-ignore lint/correctness/noUnusedVariables: `T` is consumed by the merged interface.
+export abstract class TypedEmitter<T extends EventMap<T>> extends EventEmitter {}

--- a/src/util/emitter.ts
+++ b/src/util/emitter.ts
@@ -2,49 +2,24 @@ import { EventEmitter } from "node:events";
 
 /**
  * The shape an event map has to satisfy.
- *
- * The constraint is written in terms of the map's own keys rather than as an index signature
- * (`{ [event: string]: unknown[] }`) because interfaces never get an implicit index signature and so
- * would not satisfy the latter. Requiring a `type` alias instead would cost module augmentation,
- * which is how a consumer adds their own events, so the self-referential form is the one that keeps
- * a closed, augmentable interface usable.
- * @example
- * ```ts
- * interface MyEvents {
- * 	ready: [at: number];
- * }
- * ```
+ * @description Written in terms of the map's own keys instead of an index signature: interfaces never get an implicit one, and requiring a `type` alias would cost module augmentation.
  */
 export type EventMap<T> = Record<keyof T, unknown[]>;
 
 /**
- * The event names of a map: whatever it declares, as long as the name is something an emitter can
- * actually key on.
- *
- * The intersection is load-bearing, not decoration. The merged interface below has to stay
- * compatible with the inherited `EventEmitter`, whose methods take `eventName: string | symbol`. A
- * bare `keyof T` could include `number`, which is not assignable to that, and the whole class fails
- * with TS2430 — "Interface 'TypedEmitter<T>' incorrectly extends interface 'EventEmitter<any>'".
- *
- * Note this is nothing like the open `string | symbol` union Node's own types use for event names.
- * That one accepts anything; this one only keeps the names the map declares, so a symbol it never
- * mentions is still rejected.
+ * The event names a map declares.
+ * @description The intersection keeps the merged interface assignable to the inherited signature; a bare `keyof T` may include `number` and fails with TS2430.
  */
 export type EventKey<T> = keyof T & (string | symbol);
 
 /**
- * The handler of a single event, with its parameters taken from the map's tuple. Named tuple members
- * carry over, so `[player: Player, track: Track | null]` shows those names as parameter hints.
+ * The listener of a single event, taking the parameters from the map's tuple.
  */
 export type EventListener<T extends EventMap<T>, K extends EventKey<T>> = (...args: T[K]) => void;
 
 /**
- * The emitter surface, declared in full.
- *
- * Every method is listed on purpose. Redeclaring only some of them leaves the rest resolving to the
- * inherited signature, which accepts any string and hands the listener `any` arguments — Node types
- * `on` as `on<E extends string | symbol>(event: EventNames<T, E>, ...)`, and `EventNames` includes
- * the inferred `E` itself, so nothing is ever rejected.
+ * The typed surface of the emitter.
+ * @description Every method is listed on purpose: any left out keeps resolving to the inherited signature, which takes any name and gives the listener `any` arguments.
  */
 export interface TypedEmitter<T extends EventMap<T>> {
     on<K extends EventKey<T>>(event: K, listener: EventListener<T, K>): this;
@@ -68,15 +43,10 @@ export interface TypedEmitter<T extends EventMap<T>> {
 }
 
 /**
- * An {@link EventEmitter} whose events are described by a map, so an unknown name is a compile
- * error and a handler's parameters are inferred instead of being `any`.
- *
- * The runtime is Node's emitter untouched — the class body is empty and the merged interface only
- * describes it — so listener ordering, `once` removal and `instanceof` all behave exactly as before.
- *
- * The interface merges into the class rather than the methods being redeclared as `declare` fields:
- * fields would type them as properties, and a subclass overriding `on` with ordinary method syntax
- * would then fail with TS2425, losing access to `super.on` as well.
+ * Class representing an event emitter described by a map, where an unknown event name is a compile error and a listener's parameters are inferred.
+ * @description Node's emitter is the runtime, untouched: the class body is empty and the merged interface only describes it. The interface merges instead of the methods being `declare` fields, which would type them as properties and break a subclass overriding `on` with method syntax.
+ * @abstract
+ * @class TypedEmitter
  * @example
  * ```ts
  * interface MyEvents {
@@ -91,6 +61,6 @@ export interface TypedEmitter<T extends EventMap<T>> {
  * thing.emit("ready", Date.now());
  * ```
  */
-// biome-ignore lint/suspicious/noUnsafeDeclarationMerging: the merge is the mechanism, see above.
+// biome-ignore lint/suspicious/noUnsafeDeclarationMerging: the merge is the mechanism.
 // biome-ignore lint/correctness/noUnusedVariables: `T` is consumed by the merged interface.
 export abstract class TypedEmitter<T extends EventMap<T>> extends EventEmitter {}

--- a/tests/core/emitter.test.ts
+++ b/tests/core/emitter.test.ts
@@ -1,0 +1,122 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import { TypedEmitter } from "../../src/util/emitter";
+
+const internal = Symbol("internal");
+
+interface ProbeEvents {
+    ping: [count: number];
+    named: [who: string, times: number];
+    empty: [];
+    [internal]: [flag: boolean];
+}
+
+class Probe extends TypedEmitter<ProbeEvents> {}
+
+/**
+ * The type assertions live in the same file as the runtime ones on purpose: `@ts-expect-error` fails
+ * the build when the line below it *stops* erroring, so these are what keep the surface from
+ * quietly loosening back to what `node:events` gives by default — where an unknown event name is
+ * accepted and its listener receives `any`.
+ */
+describe("TypedEmitter", () => {
+    it("keeps node's emitter behaviour", () => {
+        const probe = new Probe();
+        const seen: number[] = [];
+
+        probe.on("ping", (count) => seen.push(count));
+        probe.once("ping", (count) => seen.push(count * 100));
+
+        probe.emit("ping", 1);
+        probe.emit("ping", 2);
+
+        expect(probe).toBeInstanceOf(EventEmitter);
+        // The `once` listener ran for the first emit only.
+        expect(seen).toEqual([1, 100, 2]);
+        expect(probe.eventNames()).toEqual(["ping"]);
+    });
+
+    it("removes listeners through off and removeAllListeners", () => {
+        const probe = new Probe();
+        const seen: string[] = [];
+        const listener = (who: string): number => seen.push(who);
+
+        probe.on("named", listener);
+        probe.emit("named", "first", 1);
+
+        probe.off("named", listener);
+        probe.emit("named", "second", 2);
+
+        expect(seen).toEqual(["first"]);
+
+        probe.on("ping", () => seen.push("ping"));
+        expect(probe.listenerCount("ping")).toBe(1);
+
+        probe.removeAllListeners("ping");
+        expect(probe.listenerCount("ping")).toBe(0);
+    });
+
+    it("infers listener parameters from the event map", () => {
+        const probe = new Probe();
+
+        probe.on("named", (who, times) => {
+            // Assigning to concrete types is the assertion: `any` would compile either way, but
+            // these would then be `any` and the emit below could not be checked at all.
+            const name: string = who;
+            const count: number = times;
+
+            expect(typeof name).toBe("string");
+            expect(typeof count).toBe("number");
+        });
+
+        probe.emit("named", "hoshimi", 3);
+    });
+
+    it("supports symbol-keyed events the map declares", () => {
+        const probe = new Probe();
+        const seen: boolean[] = [];
+
+        probe.on(internal, (flag) => {
+            // Inferred from the tuple, same as for a string key.
+            const value: boolean = flag;
+            seen.push(value);
+        });
+
+        probe.emit(internal, true);
+
+        expect(seen).toEqual([true]);
+        expect(probe.eventNames()).toEqual([internal]);
+    });
+
+    it("rejects unknown names and mismatched payloads", () => {
+        // Never called: `@ts-expect-error` suppresses the diagnostic, it does not remove the call,
+        // so running these would register real listeners and emit real events. Keeping them inside
+        // an uninvoked function leaves the assertions where they belong — at compile time, where
+        // `tsc` fails the build if any of these lines stops erroring.
+        function typeAssertions(probe: Probe): void {
+            // @ts-expect-error - unknown event name on `on`
+            probe.on("thisEventDoesNotExist", () => {});
+            // @ts-expect-error - unknown event name on `once`
+            probe.once("neitherDoesThis", () => {});
+            // @ts-expect-error - unknown event name on `off`
+            probe.off("norThis", () => {});
+            // @ts-expect-error - unknown event name on `emit`
+            probe.emit("orThisOne", 1, 2, 3);
+            // @ts-expect-error - unknown event name on `removeAllListeners`
+            probe.removeAllListeners("madeUp");
+            // @ts-expect-error - listener signature does not match the map
+            probe.on("ping", (count: string) => count);
+            // @ts-expect-error - missing arguments
+            probe.emit("named", "hoshimi");
+            // @ts-expect-error - wrong argument type
+            probe.emit("ping", "not a number");
+            // @ts-expect-error - an event with no payload takes none
+            probe.emit("empty", 1);
+            // @ts-expect-error - a symbol the map never declared, so widening to `string | symbol`
+            // did not reopen the hole Node's own `string | symbol` union leaves
+            probe.on(Symbol("undeclared"), () => {});
+        }
+
+        expect(typeAssertions).toBeTypeOf("function");
+    });
+});


### PR DESCRIPTION
Replaces the typing of `Hoshimi`'s emitter. Runtime is untouched: `TypedEmitter`'s class body is empty and a merged interface describes Node's emitter, so listener order, `once` removal and `instanceof` behave exactly as before.

## Why

Node types `on` as `on<E extends string | symbol>(event: EventNames<T, E>, ...)`, and `EventNames` includes the inferred `E` itself — so no name is ever rejected. Probed against the current build:

| | before |
|---|---|
| `on("doesNotExist", …)` | accepted |
| its listener arguments | `any` |
| `emit("doesNotExist", 1, 2, 3)` | accepted |
| `on("trackStart", (p: number) => …)` | caught |

Only the last one was caught. `HoshimiEvents` is unchanged — it was already a tuple-style map, and it stays a closed, augmentable interface.

## Design notes

Both were found the hard way, so they are in the JSDoc too:

- **Interface merge, not `declare` fields.** Fields type the methods as properties, and a subclass overriding `on` with ordinary method syntax then fails with TS2425 and loses access to `super.on` — which would break anyone extending the manager.
- **`EventKey` intersects with `string | symbol`.** The merge has to stay assignable to the inherited signature; a bare `keyof T` may include `number` and fails with TS2430. Unlike Node's open union this still admits only what the map declares, symbols included.

## Verification

243 tests, `tsc` and Biome clean. The new test file pairs runtime assertions with 10 `@ts-expect-error` lines, which fail the build if any of them stops erroring.

`on` is now declared on the class instead of coming from an unresolvable base, so a consumer without `@types/node` gets it typed — it previously errored with `Property 'on' does not exist on type 'Hoshimi'`. Confirmed by building the docs against this branch with a twoslash snippet and no shim.

## Follow-up

The three shims in the docs (`events-gateway.mdx` ×2, `lyrics.mdx`) exist only for that missing `on` and can be removed once this ships — not before, since the site installs from npm.