### PR TITLE
release: v0.5.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'Ganyu-Studios/Hoshimi'
     permissions:
-      # Only npm provenance needs a token here; nothing is pushed back to the repository.
+      # npm provenance needs the first; the second is for creating the tag and the release entry.
+      # Nothing is pushed back to a branch.
       id-token: write
+      contents: write
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -39,6 +41,7 @@ jobs:
       # Publishing is skipped when that version is already on npm, so a merge that carries no bump
       # (or a re-run) is a no-op instead of a failure.
       - name: Publish to npm
+        id: publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -52,3 +55,35 @@ jobs:
           echo "Publishing hoshimi@$version"
           npm config set //registry.npmjs.org/:_authToken ${NODE_AUTH_TOKEN}
           npm publish --provenance
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # Only runs when the step above actually published: a merge carrying no bump leaves `version`
+      # unset and this is skipped, so no empty release is created.
+      #
+      # The tag drops the leading `0.`, which is the scheme every release so far follows — v3.3, v3.8
+      # and v5.2 are 0.3.3, 0.3.8 and 0.5.2. Once the package reaches 1.0.0 there is nothing to strip
+      # and the version is used as it is.
+      - name: Create the GitHub release
+        if: steps.publish.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${{ steps.publish.outputs.version }}"
+          tag="v${version#0.}"
+
+          # Same idempotency the publish step has. It matters when npm went through but this step did
+          # not: a re-run would find the version already published, skip it, and the release would
+          # never be created — so this has to be reachable and harmless on a second pass.
+          if gh release view "$tag" > /dev/null 2>&1; then
+            echo "$tag already exists, nothing to do."
+            exit 0
+          fi
+
+          echo "Tagging ${{ github.sha }} as $tag"
+
+          gh release create "$tag" \
+            --target "${{ github.sha }}" \
+            --title "Release $tag" \
+            --generate-notes \
+            --latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hoshimi",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "A lavalink@v4 client easy to use, up-to-date and all ears.",
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",

--- a/src/classes/node/Node.ts
+++ b/src/classes/node/Node.ts
@@ -14,6 +14,7 @@ import {
     type SearchQuery,
     State,
     type Stats,
+    type UserAgent,
     WebsocketCloseCodes,
 } from "../../types/Node";
 import {
@@ -33,8 +34,9 @@ import {
     Structures,
     type TrackStructure,
 } from "../../types/Structures";
+import { HoshimiAgent, HoshimiDefaultOptions } from "../../util/constants";
 import { clearHeartbeatTimer, onClose, onError, onMessage, onOpen } from "../../util/events/websocket";
-import { censor, stringify } from "../../util/functions/utils";
+import { censor, stringify, toHeaderValue } from "../../util/functions/utils";
 import { Validations } from "../../util/functions/validations";
 import { NodeError } from "../Errors";
 
@@ -400,13 +402,18 @@ export class Node {
                 id: this.id,
             });
 
+        const previous: State = this.state;
+
         this.state = State.Connecting;
 
+        // `Client-Name` is the bot's name as Discord gives it, so it can hold anything a user can
+        // type. Everything that reaches a header goes through the same cleaning, since one bad
+        // character makes the WebSocket constructor throw and leaves the node unusable.
         const headers: ResumableHeaders = {
             Authorization: this.options.password,
             "User-Id": this.nodeManager.manager.options.client.id,
-            "Client-Name": this.nodeManager.manager.options.client.username!,
-            "User-Agent": this.rest.userAgent,
+            "Client-Name": toHeaderValue(this.nodeManager.manager.options.client.username!, HoshimiDefaultOptions.client.username),
+            "User-Agent": toHeaderValue(this.rest.userAgent, HoshimiAgent) as UserAgent,
         };
 
         if (this.options.sessionId) {
@@ -419,7 +426,15 @@ export class Node {
             );
         }
 
-        this.ws = new WebSocket(this.address, { headers: { ...headers } });
+        // A throw here — a malformed address, a header the cleaning could not save — would otherwise
+        // leave the state on `Connecting`, and every later attempt returns early on that, so the node
+        // would stay dead for the rest of the process instead of retrying.
+        try {
+            this.ws = new WebSocket(this.address, { headers: { ...headers } });
+        } catch (error) {
+            this.state = previous;
+            throw error;
+        }
 
         this.ws.on("upgrade", onOpen.bind(this));
         this.ws.on("message", onMessage.bind(this));

--- a/src/util/functions/utils.ts
+++ b/src/util/functions/utils.ts
@@ -67,6 +67,19 @@ export function isPlayerGone(player: PlayerStructure, scope: PlayerScope): boole
 
 /**
  *
+ * Make a value safe to send as an HTTP header.
+ * @description Node throws `ERR_INVALID_CHAR` for anything outside printable ASCII, and `Client-Name` carries the bot's name straight from Discord — an emoji or a non-latin script in it takes the whole connection down. Offending characters are dropped rather than transliterated, since the header is only ever read by a human in the node's logs.
+ * @param {string} value The value to clean.
+ * @param {string} fallback The value to use when nothing printable is left.
+ * @returns {string} A value that will not be rejected as a header.
+ */
+export function toHeaderValue(value: string, fallback: string): string {
+    const cleaned: string = value.replace(/[^\x20-\x7E]/g, "").trim();
+    return cleaned.length ? cleaned : fallback;
+}
+
+/**
+ *
  * Check if the value is defined (not undefined or null).
  * @param {unknown} value
  * @returns {boolean} True if the value is defined, false otherwise.

--- a/tests/node/headers.test.ts
+++ b/tests/node/headers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { State } from "../../src/types/Node";
+import { HoshimiDefaultOptions } from "../../src/util/constants";
+import { toHeaderValue } from "../../src/util/functions/utils";
+import { createRealManager } from "../helpers";
+
+/**
+ * `Client-Name` carries the bot's name exactly as Discord hands it over, so it can hold an emoji, a
+ * non-latin script or a line break. Node rejects all of those with `ERR_INVALID_CHAR` from the
+ * WebSocket constructor, which took the node down and — because the state had already been moved to
+ * `Connecting` — left it there, silently ignoring every later attempt.
+ */
+describe("Header sanitisation", () => {
+    it("keeps what a header may carry", () => {
+        expect(toHeaderValue("Stelle", "fallback")).toBe("Stelle");
+        expect(toHeaderValue("Ganyu Studios", "fallback")).toBe("Ganyu Studios");
+        expect(toHeaderValue("hoshimi/v0.5.2 (https://example.com)", "fallback")).toBe("hoshimi/v0.5.2 (https://example.com)");
+    });
+
+    it("drops what it may not", () => {
+        expect(toHeaderValue("Stelle 🌟", "fallback")).toBe("Stelle");
+        expect(toHeaderValue("Sténle", "fallback")).toBe("Stnle");
+        expect(toHeaderValue("Ste\nlle", "fallback")).toBe("Stelle");
+        expect(toHeaderValue("Ste\rlle", "fallback")).toBe("Stelle");
+    });
+
+    it("falls back when nothing printable is left", () => {
+        expect(toHeaderValue("星見", "hoshimi-client")).toBe("hoshimi-client");
+        expect(toHeaderValue("🌟", "hoshimi-client")).toBe("hoshimi-client");
+        expect(toHeaderValue("   ", "hoshimi-client")).toBe("hoshimi-client");
+    });
+
+    it("connects with a username node would have rejected", () => {
+        const manager = createRealManager();
+        manager.options.client = { id: "123456789", username: "Stelle 🌟" };
+
+        const node = manager.nodeManager.create({
+            host: "127.0.0.1",
+            port: 1,
+            password: "pass",
+            id: "emoji",
+            retryAmount: 0,
+        });
+
+        expect(() => node.connect()).not.toThrow();
+        expect(node.ws).not.toBeNull();
+
+        node.ws?.on("error", () => {});
+        node.ws?.terminate();
+    });
+
+    it("sends the fallback when the name has nothing usable", () => {
+        const manager = createRealManager();
+        manager.options.client = { id: "123456789", username: "星見" };
+
+        const node = manager.nodeManager.create({
+            host: "127.0.0.1",
+            port: 1,
+            password: "pass",
+            id: "cjk",
+            retryAmount: 0,
+        });
+
+        node.connect();
+
+        // The request `ws` built is where the header actually landed, so this reads what would go
+        // out on the wire rather than what we meant to send.
+        const request = (node.ws as unknown as { _req: { getHeader(name: string): string } })._req;
+
+        expect(request.getHeader("client-name")).toBe(HoshimiDefaultOptions.client.username);
+        expect(request.getHeader("user-id")).toBe("123456789");
+
+        node.ws?.on("error", () => {});
+        node.ws?.terminate();
+    });
+
+    it("leaves the state alone when the socket cannot be built", () => {
+        const manager = createRealManager();
+        manager.options.client = { id: "123456789", username: "Stelle" };
+
+        const node = manager.nodeManager.create({
+            host: "127.0.0.1",
+            port: 1,
+            password: "pass",
+            id: "bad-address",
+            retryAmount: 0,
+        });
+
+        // An address the WebSocket constructor refuses, standing in for anything that throws there.
+        vi.spyOn(node, "address", "get").mockReturnValue("not-a-valid-url");
+
+        const before: State = node.state;
+
+        expect(() => node.connect()).toThrow();
+        // Without the restore this stays on `Connecting`, and `connect` returns early on that
+        // forever after, so the node would never reconnect.
+        expect(node.state).toBe(before);
+        expect(node.state).not.toBe(State.Connecting);
+    });
+});


### PR DESCRIPTION
Publishes `0.5.3`. The merge triggers the Publish workflow, which now also creates the release entry.

## Fix

`Client-Name` carried the bot's name exactly as Discord hands it over, and Node rejects anything outside printable ASCII with `ERR_INVALID_CHAR` from the WebSocket constructor. A name with an emoji or a non-latin script could not connect at all.

Worse than a failed connection: `state` had already been set to `Connecting` before the constructor ran, and `connect()` returns early on that state, so every later attempt — including reconnects — silently did nothing. `init()` catches the throw and emits `nodeError`, so nothing crashes; the bot simply has no audio for the rest of the process.

| username | before |
|---|---|
| `Stelle`, `Ganyu Studios`, `Sténle` | connects |
| `Stelle 🌟`, `星見`, `Ste\nlle` | `ERR_INVALID_CHAR`, node wedged |

Values that reach a header are now stripped to printable ASCII, falling back to `hoshimi-client` when nothing usable is left. The WebSocket construction restores the previous state before rethrowing, so a throw there can no longer wedge the node.

## Verification

249 tests, `tsc` and Biome clean. Six new tests, each confirmed to fail against the previous code: two break without the sanitiser, one without the state restore.

## Note

The README still suggests `init({ ...user, username: user.username })`, which is the case that used to break. It is safe now, but the example is worth revisiting — and `Client-Name` is specified as `NAME/VERSION`, which this does not follow.