### PR TITLE
release: v0.5.5

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# Mirrors biome.json so an editor formats the way Biome does. Biome reads this file
+# (useEditorconfig is on by default) and biome.json takes precedence, so the two must agree.
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 140
+
+# Biome formats JSON at a narrower width than the rest.
+[*.json]
+max_line_length = 80
+
+# Not formatted by Biome; keep the conventional two-space indent so an editor does not
+# re-indent the workflows or the generated lockfile.
+[*.{yml,yaml}]
+indent_size = 2
+
+# Trailing spaces are a hard line break in Markdown.
+[*.md]
+trim_trailing_whitespace = false
+
+# Hooks and shell scripts run under `sh`; a CR in the shebang breaks them. Matches .gitattributes.
+[.husky/**]
+end_of_line = lf
+
+[*.sh]
+end_of_line = lf

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
     "assist": {
         "actions": {
             "source": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hoshimi",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "description": "A lavalink@v4 client easy to use, up-to-date and all ears.",
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.cts",
-    "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1",
+    "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621",
     "exports": {
         ".": {
             "types": "./dist/index.d.cts",
@@ -48,7 +48,7 @@
     "author": "Ganyu Studios",
     "license": "MIT",
     "devDependencies": {
-        "@biomejs/biome": "^2.5.8",
+        "@biomejs/biome": "^2.5.9",
         "@types/node": "^26.2.0",
         "@types/ws": "^8.18.1",
         "husky": "^9.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 8.21.3
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.8
-        version: 2.5.8
+        specifier: ^2.5.9
+        version: 2.5.9
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
@@ -42,59 +42,59 @@ importers:
 
 packages:
 
-  '@biomejs/biome@2.5.8':
-    resolution: {integrity: sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw==}
+  '@biomejs/biome@2.5.9':
+    resolution: {integrity: sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.8':
-    resolution: {integrity: sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA==}
+  '@biomejs/cli-darwin-arm64@2.5.9':
+    resolution: {integrity: sha512-am22pX2aBqznqq1eMyIj/bZ++riF3Lk6ct7cbv+gQK0csFhr+d8O0RkOi2FF2qSgFgANbqNkIZ0/PxlnW2pLFg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.8':
-    resolution: {integrity: sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w==}
+  '@biomejs/cli-darwin-x64@2.5.9':
+    resolution: {integrity: sha512-l44KWDHLDvEnD0N/XcrVs7VXb3A18xL7QS3WB0eL93wbmk529ffIG55vleGCqaunpRUjLrdnjK05Qki1dsjylg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.8':
-    resolution: {integrity: sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.9':
+    resolution: {integrity: sha512-7ImVPwBLCtkmpR5esd8RHhTqW94f0JLJQum6AneYcy94jRm18TaPPm7slaigGzFhfgt3QiD1Vj52LKmBAnKizA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.8':
-    resolution: {integrity: sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ==}
+  '@biomejs/cli-linux-arm64@2.5.9':
+    resolution: {integrity: sha512-ICaK+IYaVZvKbBxX2rwrPT0DdUDMnE9Vm3nQGe+mltQPmUg19pONzkPWGdY4FCsoreDETWDynvdt4ysCbF5gNQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.8':
-    resolution: {integrity: sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w==}
+  '@biomejs/cli-linux-x64-musl@2.5.9':
+    resolution: {integrity: sha512-RXGaD0o1/pTTguYw1aeDJh9ad6Lfrui0fI7mBderTyGr7WuUJkBIttgLkR3XJyoxOkkgfBDspaUT8wXArTqLZw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.8':
-    resolution: {integrity: sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ==}
+  '@biomejs/cli-linux-x64@2.5.9':
+    resolution: {integrity: sha512-z22Q/zFYSvbIJfW1CbfZPu4X8PddS6Qd2ORbc6h+aT6EcwAxUF3m6fA4HjNvA3TU4X0dTJRwNPB165ES3PJXzg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.8':
-    resolution: {integrity: sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA==}
+  '@biomejs/cli-win32-arm64@2.5.9':
+    resolution: {integrity: sha512-nHK+/HHC+D0ogAHUxomgoSTdjImb6fmNNVTKmf0tyu4eDL1DqPKIHc+i+UL8+b0RnAu8224qo8F2tCVnaT0A3w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.8':
-    resolution: {integrity: sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA==}
+  '@biomejs/cli-win32-x64@2.5.9':
+    resolution: {integrity: sha512-Yiq0H56LjXSSw/hd9YkXgSLQfzyDJzbzU2TezozxyNw+uKWAqOtqGVvBfzKRRDiaFF5avGAhHdWKx7LtDOShUw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1210,39 +1210,39 @@ packages:
 
 snapshots:
 
-  '@biomejs/biome@2.5.8':
+  '@biomejs/biome@2.5.9':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.8
-      '@biomejs/cli-darwin-x64': 2.5.8
-      '@biomejs/cli-linux-arm64': 2.5.8
-      '@biomejs/cli-linux-arm64-musl': 2.5.8
-      '@biomejs/cli-linux-x64': 2.5.8
-      '@biomejs/cli-linux-x64-musl': 2.5.8
-      '@biomejs/cli-win32-arm64': 2.5.8
-      '@biomejs/cli-win32-x64': 2.5.8
+      '@biomejs/cli-darwin-arm64': 2.5.9
+      '@biomejs/cli-darwin-x64': 2.5.9
+      '@biomejs/cli-linux-arm64': 2.5.9
+      '@biomejs/cli-linux-arm64-musl': 2.5.9
+      '@biomejs/cli-linux-x64': 2.5.9
+      '@biomejs/cli-linux-x64-musl': 2.5.9
+      '@biomejs/cli-win32-arm64': 2.5.9
+      '@biomejs/cli-win32-x64': 2.5.9
 
-  '@biomejs/cli-darwin-arm64@2.5.8':
+  '@biomejs/cli-darwin-arm64@2.5.9':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.8':
+  '@biomejs/cli-darwin-x64@2.5.9':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.8':
+  '@biomejs/cli-linux-arm64-musl@2.5.9':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.8':
+  '@biomejs/cli-linux-arm64@2.5.9':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.8':
+  '@biomejs/cli-linux-x64-musl@2.5.9':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.8':
+  '@biomejs/cli-linux-x64@2.5.9':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.8':
+  '@biomejs/cli-win32-arm64@2.5.9':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.8':
+  '@biomejs/cli-win32-x64@2.5.9':
     optional: true
 
   '@emnapi/core@1.11.1':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,15 +2,15 @@ allowBuilds:
   esbuild: true
 
 minimumReleaseAgeExclude:
-  - '@biomejs/biome@2.5.3 || 2.5.4'
-  - '@biomejs/cli-darwin-arm64@2.5.3 || 2.5.4'
-  - '@biomejs/cli-darwin-x64@2.5.3 || 2.5.4'
-  - '@biomejs/cli-linux-arm64-musl@2.5.3 || 2.5.4'
-  - '@biomejs/cli-linux-arm64@2.5.3 || 2.5.4'
-  - '@biomejs/cli-linux-x64-musl@2.5.3 || 2.5.4'
-  - '@biomejs/cli-linux-x64@2.5.3 || 2.5.4'
-  - '@biomejs/cli-win32-arm64@2.5.3 || 2.5.4'
-  - '@biomejs/cli-win32-x64@2.5.3 || 2.5.4'
+  - '@biomejs/biome@2.5.3 || 2.5.4 || 2.5.9'
+  - '@biomejs/cli-darwin-arm64@2.5.3 || 2.5.4 || 2.5.9'
+  - '@biomejs/cli-darwin-x64@2.5.3 || 2.5.4 || 2.5.9'
+  - '@biomejs/cli-linux-arm64-musl@2.5.3 || 2.5.4 || 2.5.9'
+  - '@biomejs/cli-linux-arm64@2.5.3 || 2.5.4 || 2.5.9'
+  - '@biomejs/cli-linux-x64-musl@2.5.3 || 2.5.4 || 2.5.9'
+  - '@biomejs/cli-linux-x64@2.5.3 || 2.5.4 || 2.5.9'
+  - '@biomejs/cli-win32-arm64@2.5.3 || 2.5.4 || 2.5.9'
+  - '@biomejs/cli-win32-x64@2.5.3 || 2.5.4 || 2.5.9'
   - '@types/node@26.1.1 || 26.2.0'
   - tsdown@0.22.4 || 0.22.5 || 0.22.7 || 0.22.8 || 0.22.14
   - rolldown-plugin-dts@0.27.8

--- a/src/classes/Errors.ts
+++ b/src/classes/Errors.ts
@@ -108,7 +108,7 @@ export class RestError extends Error {
      */
     public error: string;
     /**
-     * The message of the response.
+     * The path of the response.
      * @type {string}
      */
     public path: string;

--- a/src/classes/Hoshimi.ts
+++ b/src/classes/Hoshimi.ts
@@ -68,7 +68,7 @@ type GatewayPackets = VoicePacket | VoiceServer | VoiceState | ChannelDeletePack
 export class Hoshimi extends TypedEmitter<HoshimiEvents> {
     /**
      * The options for the manager.
-     * @type {HoshimiOptions}
+     * @type {RequiredHoshimiOptions}
      */
     public options: RequiredHoshimiOptions;
 
@@ -118,14 +118,16 @@ export class Hoshimi extends TypedEmitter<HoshimiEvents> {
      * 	},
      * 	nodeOptions: {
      * 		userAgent: HoshimiAgent,
-     * 		resumable: false,
-     * 		resumeByLibrary: false,
+     * 		sessionOptions: {
+     * 			resumable: false,
+     * 			byLibrary: false,
+     * 		},
      * 	},
      * 	queueOptions: {
      *      maxHistory: 25,
      *      autoplayFn: autoplayFn,
      *      autoPlay: false,
-     *      storage: new MemoryAdapter(),
+     *      storage: new QueueMemoryStorage(),
      * 	},
      *   playerOptions: {
      *      requesterFn: defaultRequesterFn,

--- a/src/classes/Track.ts
+++ b/src/classes/Track.ts
@@ -60,7 +60,7 @@ export class Track implements LavalinkTrack {
 
     /**
      * The constructor for the track.
-     * @param {LavalinkTrack} track The track to construct the track from.
+     * @param {LavalinkTrack | null} track The track to construct the track from.
      * @param {TrackRequester} requester The requester of the track.
      * @example
      * ```ts

--- a/src/classes/node/Lyrics.ts
+++ b/src/classes/node/Lyrics.ts
@@ -31,12 +31,13 @@ export class LyricsManager {
     /**
      *
      * Get the current lyrics for the current track.
+     * @param {string} guildId The guild id to get the current lyrics for.
      * @param {boolean} skipSource Whether to skip the track source or not.
      * @returns {Promise<LyricsResult | null>} The lyrics result or null if not found.
      * @example
      * ```ts
-     * const player = manager.getPlayer("guildId");
-     * const lyrics = await player.lyricsManager.current();
+     * const node = manager.nodeManager.get("nodeId");
+     * const lyrics = await node.lyricsManager.current("guildId");
      * ```
      */
     public async current(guildId: string, skipSource: boolean = false): Promise<LyricsResult | null> {

--- a/src/classes/node/Node.ts
+++ b/src/classes/node/Node.ts
@@ -199,7 +199,7 @@ export class Node {
     /**
      *
      * Define a custom event handler for the node.
-     * @param {P} payload The payload to send to the node.
+     * @param {unknown} payload The payload received from the node.
      * @returns {Awaitable<void>}
      * @example
      * ```ts

--- a/src/classes/node/Rest.ts
+++ b/src/classes/node/Rest.ts
@@ -243,12 +243,11 @@ export class Rest {
      *
      * Destroy the player for the guild.
      * @param {string} guildId The guild id to destroy the player.
-     * @returns {Promise<void>} The updated player data.
+     * @returns {Promise<void>}
      * @example
      * ```ts
      * await node.rest.destroyPlayer("guildId");
      * ```
-     * @example
      */
     public async destroyPlayer(guildId: string): Promise<void> {
         if (!this.sessionId || this.node.state !== State.Connected) {

--- a/src/classes/player/Player.ts
+++ b/src/classes/player/Player.ts
@@ -200,7 +200,7 @@ export class Player {
      *
      * Create a new player.
      * @param {Hoshimi} manager The manager for the player.
-     * @param {PlayOptions} options The options for the player.
+     * @param {PlayerOptions} options The options for the player.
      * @example
      * ```ts
      * const player = Structures.Player(manager, {
@@ -559,7 +559,7 @@ export class Player {
      * @example
      * ```ts
      * const player = manager.getPlayer("guildId");
-     * player.destroy(DestroyReasons.Stop);
+     * player.destroy({ reason: DestroyReasons.Stop });
      * ```
      */
     public async destroy(options: DestroyOptions = {}): Promise<void> {
@@ -598,7 +598,8 @@ export class Player {
     /**
      *
      * Pause or resume the player.
-     * @returns {Promise<void>}
+     * @param {boolean} [paused=!this.paused] Whether to pause; defaults to toggling the current state.
+     * @returns {Promise<boolean>} The resulting paused state.
      * @example
      * ```ts
      * const player = manager.getPlayer("guildId");
@@ -653,6 +654,7 @@ export class Player {
      *
      * Set the loop mode of the player.
      * @param {LoopMode} mode The loop mode to set.
+     * @returns {this} The player instance.
      * @throws {PlayerError} If the loop mode is invalid.
      * @example
      * ```ts

--- a/src/classes/player/Voice.ts
+++ b/src/classes/player/Voice.ts
@@ -225,7 +225,7 @@ export class PlayerVoiceState {
 
     /**
      * Disconnect the player from voice.
-     * @returns {Promise<PlayerStructure>} The player structure after disconnecting.
+     * @returns {Promise<void>}
      * @example
      * ```ts
      * const player = manager.getPlayer("guildId");

--- a/src/classes/queue/Queue.ts
+++ b/src/classes/queue/Queue.ts
@@ -294,23 +294,17 @@ export class Queue {
 
     /**
      * Clear the queue.
+     * @description Empties the upcoming tracks and the history and drops the stored queue. The current
+     * track and playback are left untouched.
      * @returns {Promise<this>} The queue instance.
      * @example
      * ```ts
      * const queue = player.queue;
      *
-     * // Clear queue and stop playback
-     * console.log(queue.size); // 0
-     * await queue.add(track);
      * await queue.add(track1, track2);
-     * await queue.clear();
-     * console.log(queue.current); // track
-     * console.log(queue.size); // 0
+     * console.log(queue.size); // 2
      *
-     * // Keep current track
-     * await queue.add(track);
      * await queue.clear();
-     * console.log(queue.current); // track
      * console.log(queue.size); // 0
      * ```
      */

--- a/src/classes/queue/Utils.ts
+++ b/src/classes/queue/Utils.ts
@@ -14,8 +14,8 @@ import type { TrackRequester, TrackResolvableStructure } from "../Track";
  */
 export class QueueUtils {
     /**
-     * Player instance.
-     * @type {Queue}
+     * Queue instance.
+     * @type {QueueStructure}
      * @private
      * @readonly
      * @internal
@@ -53,7 +53,7 @@ export class QueueUtils {
     /**
      * Build a track from a resolvable structure.
      * Automatically resolves UnresolvedTrack instances to avoid double resolution.
-     * @param {TrackResolvableStructure | null} track The input track.
+     * @param {TrackResolvableStructure | AnyLavalinkTrack | null} [track] The input track.
      * @param {TrackRequester} [requester] Optional requester override.
      * @returns {Promise<TrackStructure | null>} The built and resolved track.
      */
@@ -121,7 +121,7 @@ export class QueueUtils {
     /**
      *
      * Destroy the queue, removing all stored data.
-     * @returns {Promise<void>}
+     * @returns {Awaitable<boolean>} Whether the stored queue entry was deleted.
      * @example
      * ```ts
      * await player.queue.utils.destroy();

--- a/src/classes/storage/adapters/PlayerAdapter.ts
+++ b/src/classes/storage/adapters/PlayerAdapter.ts
@@ -121,7 +121,7 @@ export abstract class PlayerStorageAdapter {
      *
      * Get the value using the key.
      * @param {string} key The key to get the value from.
-     * @returns {Awaitable<T | undefined>} The value of the key.
+     * @returns {Awaitable<V | undefined>} The value of the key.
      * @example
      * ```ts
      * const value = await storage.get("key");

--- a/src/classes/storage/adapters/QueueAdapter.ts
+++ b/src/classes/storage/adapters/QueueAdapter.ts
@@ -96,7 +96,7 @@ export abstract class QueueStorageAdapter<T extends QueueJSON = QueueJSON> {
      * @returns {T} The parsed value.
      * @example
      * ```ts
-     * const parsed = await storage.parse<{ key: string }>("{'key':'value'}");
+     * const parsed = await storage.parse("{'key':'value'}");
      * console.log(parsed); // { key: "value" }
      * ```
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export * from "./util/constants";
 // Exports related to the typed event emitter. Part of the public surface because `Hoshimi` extends
 // it: without this, a consumer's `Hoshimi` type would reference a name they cannot resolve.
 export * from "./util/emitter";
-
+// The built-in `byLibrary` resume handler, exported so a custom `resumeFn` can reuse or wrap it.
+export { resumeByLibrary } from "./util/events/player";
 // Exports related to track utilities.
 export { TrackResolution } from "./util/functions/track";

--- a/src/registry/SourceRegistry.ts
+++ b/src/registry/SourceRegistry.ts
@@ -150,7 +150,7 @@ export const SourceRegistry = {
     },
     /**
      * Get the canonical source from an alias or source name.
-     * @param {Hint<RegistrySearchSource>} value The value to resolve.
+     * @param {RegistrySearchSource} value The value to resolve.
      * @returns {string | undefined} The canonical source identifier.
      */
     resolve(value: RegistrySearchSource): string | undefined {
@@ -161,7 +161,7 @@ export const SourceRegistry = {
     },
     /**
      * Checks whether a source is registered.
-     * @param {Hint<RegistrySearchSource>} value The value to check.
+     * @param {RegistrySearchSource} value The value to check.
      * @returns {boolean} Whether the source is registered.
      */
     isRegistered(value: RegistrySearchSource): boolean {

--- a/src/types/Manager.ts
+++ b/src/types/Manager.ts
@@ -656,14 +656,14 @@ export interface HoshimiEvents {
      * Emitted when the track is stuck.
      * @param {PlayerStructure} player The player that emitted the event.
      * @param {TrackStructure | null} track The track that was stuck.
-     * @param {TrackEndEvent} payload The payload of the event.
+     * @param {TrackStuckEvent} payload The payload of the event.
      */
     trackStuck: [player: PlayerStructure, track: TrackStructure | null, payload: TrackStuckEvent];
     /**
      * Emitted when a track is errored.
      * @param {PlayerStructure} player The player that emitted the event.
      * @param {TrackStructure | null} track The track that was errored.
-     * @param {TrackEndEvent} payload The payload of the event.
+     * @param {TrackExceptionEvent} payload The payload of the event.
      */
     trackError: [player: PlayerStructure, track: TrackStructure | null, payload: TrackExceptionEvent];
 
@@ -685,7 +685,7 @@ export interface HoshimiEvents {
      * Emitted when a line of lyrics is updated.
      * @param {PlayerStructure} player The player that emitted the event.
      * @param {TrackStructure | null} track The track that was updated.
-     * @param {LyricsFoundEvent} payload The lyrics that were updated.
+     * @param {LyricsLineEvent} payload The lyrics that were updated.
      */
     lyricsLine: [player: PlayerStructure, track: TrackStructure | null, payload: LyricsLineEvent];
 
@@ -736,7 +736,7 @@ export interface QueryResult {
     tracks: TrackStructure[];
     /**
      * The plugin info of the search result.
-     * @type {PluginInfo}
+     * @type {PluginInfo | null}
      */
     pluginInfo: PluginInfo | null;
 }
@@ -823,12 +823,12 @@ export interface VoiceState {
      */
     deaf: boolean;
     /**
-     * The self mute status of the voice state.
+     * The self deaf status of the voice state.
      * @type {boolean}
      */
     self_deaf: boolean;
     /**
-     * The self video status of the voice state.
+     * The self mute status of the voice state.
      * @type {boolean}
      */
     self_mute: boolean;

--- a/src/types/Node.ts
+++ b/src/types/Node.ts
@@ -1,7 +1,7 @@
 import type { TrackUserData } from "../classes/Track";
 import type { CustomizableSources } from "../registry/SourceRegistry";
 import type { FilterType } from "./Filters";
-import type { Hint, PickRequired, Prettify, SearchSource } from "./Manager";
+import type { Awaitable, Hint, PickRequired, Prettify, SearchSource } from "./Manager";
 import type {
     LyricsFoundEvent,
     LyricsLineEvent,
@@ -13,7 +13,7 @@ import type {
     TrackStuckEvent,
     WebSocketClosedEvent,
 } from "./Player";
-import type { NodeStructure } from "./Structures";
+import type { NodeStructure, PlayerStructure } from "./Structures";
 
 /**
  * The states.
@@ -1194,6 +1194,14 @@ export interface NodeSessionOptions {
      * @default false
      */
     byLibrary?: boolean;
+    /**
+     * Custom handler for `byLibrary` resume. When set, it runs instead of the built-in one; when
+     * omitted, the built-in `resumeByLibrary` is used. Only consulted while `byLibrary` is enabled.
+     * @param {NodeStructure} node The node whose players are being resumed.
+     * @param {PlayerStructure[]} players The players the library holds for that node.
+     * @returns {Awaitable<void>}
+     */
+    resumeFn?(node: NodeStructure, players: PlayerStructure[]): Awaitable<void>;
 }
 
 export interface NodePlayerMoveOptions {

--- a/src/types/Node.ts
+++ b/src/types/Node.ts
@@ -193,47 +193,47 @@ export enum SourceNames {
      */
     TextToSpeech = "tts",
     /**
-     * Play voice using text to speech.
+     * Play from Clyp.it.
      * @description Provided by skybot-lavalink-plugin.
      */
     Clypit = "clypit",
     /**
-     * Play voice using text to speech.
+     * Play from Stream Deck audio.
      * @description Provided by skybot-lavalink-plugin.
      */
     StreamDeckAudio = "StreamDeckAudio",
     /**
-     * Play voice using text to speech.
+     * Play from getyarn.io.
      * @description Provided by skybot-lavalink-plugin.
      */
     GetYarn = "getyarn.io",
     /**
-     * Play voice using text to speech.
+     * Play from MixCloud.
      * @description Provided by skybot-lavalink-plugin.
      */
     MixCloud = "mixcloud",
     /**
-     * Play voice using text to speech.
+     * Play from OverClocked ReMix.
      * @description Provided by skybot-lavalink-plugin.
      */
     OCRemix = "ocremix",
     /**
-     * Play voice using text to speech.
+     * Play from PixelDrain.
      * @description Provided by skybot-lavalink-plugin.
      */
     PixelDrain = "pixeldrain",
     /**
-     * Play voice using text to speech.
+     * Play from Reddit.
      * @description Provided by skybot-lavalink-plugin.
      */
     Reddit = "reddit",
     /**
-     * Play voice using text to speech.
+     * Play from SoundGasm.
      * @description Provided by skybot-lavalink-plugin.
      */
     SoundGasm = "soundgasm",
     /**
-     * Play voice using text to speech.
+     * Play from TikTok.
      * @description Provided by skybot-lavalink-plugin.
      */
     TikTok = "tiktok",
@@ -271,15 +271,15 @@ export enum PluginInfoType {
      */
     Album = "album",
     /**
-     * The plugin information type is track.
+     * The plugin information type is playlist.
      */
     Playlist = "playlist",
     /**
-     * The plugin information type is track.
+     * The plugin information type is artist.
      */
     Artist = "artist",
     /**
-     * The plugin information type is track.
+     * The plugin information type is recommendations.
      */
     Recommendations = "recommendations",
 }
@@ -1048,7 +1048,7 @@ export interface NodeInfo {
     plugins: NodeInfoPlugin[];
     /**
      * Whether the node is a Nodelink instance.
-     * @type {boolean
+     * @type {boolean}
      */
     isNodelink: boolean;
 }

--- a/src/types/Player.ts
+++ b/src/types/Player.ts
@@ -507,8 +507,8 @@ export interface PlayerVoice {
      */
     channelId?: string;
     /**
-     * The voice server guild id.
-     * @type {string | undefined}
+     * The voice connection state.
+     * @type {boolean | undefined}
      */
     connected?: boolean;
     /**
@@ -544,7 +544,7 @@ export interface PlayerJSON {
     selfMute: boolean;
     /**
      * The voice settings for the player.
-     * @type {LavalinkPlayerVoice}
+     * @type {Nullable<LavalinkPlayerVoice>}
      */
     voice: Nullable<LavalinkPlayerVoice>;
     /**
@@ -554,7 +554,7 @@ export interface PlayerJSON {
     loop: LoopMode;
     /**
      * The options for the player.
-     * @type {boolean}
+     * @type {PlayerOptions}
      */
     options: PlayerOptions;
     /**

--- a/src/types/Queue.ts
+++ b/src/types/Queue.ts
@@ -30,7 +30,7 @@ export interface HoshimiQueueOptions {
     /**
      * The storage manager to use for the queue.
      * @type {QueueStorageAdapter}
-     * @default {MemoryAdapter}
+     * @default {QueueMemoryStorage}
      */
     storage?: QueueStorageAdapter;
 }
@@ -66,17 +66,17 @@ export interface TrackJSON extends LavalinkTrack {
 export interface QueueJSON {
     /**
      * The tracks of the queue.
-     * @type {TrackResolvableStructure[]}
+     * @type {TrackJSON[]}
      */
     tracks: TrackJSON[];
     /**
      * The previous tracks of the queue.
-     * @type {TrackStructure[]}
+     * @type {TrackJSON[]}
      */
     history: TrackJSON[];
     /**
      * The current track of the queue.
-     * @type {TrackStructure | null}
+     * @type {TrackJSON | null}
      */
     current: TrackJSON | null;
 }

--- a/src/util/collection.ts
+++ b/src/util/collection.ts
@@ -7,7 +7,6 @@ export class Collection<K, V> extends Map<K, V> {
     /**
      * Removes elements from the collection based on a filter function.
      * @param fn The filter function that determines which elements to remove.
-     * @param thisArg The value to use as `this` when executing the filter function.
      * @returns The number of elements removed from the collection.
      * @example
      * const collection = new Collection<number, string>();
@@ -31,7 +30,6 @@ export class Collection<K, V> extends Map<K, V> {
     /**
      * Creates a new array with the results of calling a provided function on every element in the collection.
      * @param fn The function that produces an element of the new array.
-     * @param thisArg The value to use as `this` when executing the map function.
      * @returns A new array with the results of calling the provided function on every element in the collection.
      * @example
      * const collection = new Collection<number, string>();
@@ -56,7 +54,6 @@ export class Collection<K, V> extends Map<K, V> {
     /**
      * Creates a new array with all elements that pass the test implemented by the provided function.
      * @param fn The function to test each element of the collection.
-     * @param thisArg The value to use as `this` when executing the filter function.
      * @returns A new array with the elements that pass the test.
      * @example
      * const collection = new Collection<number, string>();

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -5,6 +5,7 @@ import { AudioOutput } from "../types/Filters";
 import { type RequiredHoshimiOptions, SearchSources } from "../types/Manager";
 import { NodeSortTypes, type UserAgent } from "../types/Node";
 import { LoopMode } from "../types/Player";
+import { resumeByLibrary } from "./events/player";
 import { autoplayFn } from "./functions/autoplay";
 import { requesterFn } from "./functions/utils";
 
@@ -102,6 +103,7 @@ export const HoshimiDefaultOptions: Readonly<RequiredHoshimiOptions> = Object.fr
             resumable: false,
             timeout: 60,
             byLibrary: false,
+            resumeFn: resumeByLibrary,
         },
         moveOptions: {
             filterBy: NodeSortTypes.Penalties,

--- a/src/util/events/player.ts
+++ b/src/util/events/player.ts
@@ -348,19 +348,20 @@ export async function socketClosed(this: PlayerStructure, payload: WebSocketClos
 
 /**
  *
- * Resumes players by library.
- * @param {NodeStructure} this The node that is resuming the players.
+ * Resumes players by library. The default handler for {@link NodeSessionOptions.byLibrary}; exported
+ * so a custom `resumeFn` can reuse or wrap it.
+ * @param {NodeStructure} node The node that is resuming the players.
  * @param {PlayerStructure[]} players The players to be resumed.
- * @returns {Promise<void>} Nothing.
+ * @returns {Promise<void>}
  */
-export async function resumeByLibrary(this: NodeStructure, players: PlayerStructure[]): Promise<void> {
-    this.nodeManager.manager.debug(DebugLevels.Node, `[Socket] -> [${this.id}]: Resuming session by library...`);
+export async function resumeByLibrary(node: NodeStructure, players: PlayerStructure[]): Promise<void> {
+    node.nodeManager.manager.debug(DebugLevels.Node, `[Socket] -> [${node.id}]: Resuming session by library...`);
 
     for (const player of players) {
         if (await player.data.get("internal_nodeChange")) continue;
         try {
             if (!player.isPlaying() && !player.queue.totalSize) {
-                this.nodeManager.manager.debug(
+                node.nodeManager.manager.debug(
                     DebugLevels.Node,
                     `[Player] -> [Resume] Destroyed player for guild ${player.guildId} due to empty queue.`,
                 );
@@ -372,7 +373,7 @@ export async function resumeByLibrary(this: NodeStructure, players: PlayerStruct
 
             const voice: LavalinkPlayerVoice | null = player.voice.toNode();
             if (!voice) {
-                this.nodeManager.manager.debug(
+                node.nodeManager.manager.debug(
                     DebugLevels.Node,
                     `[Player] -> [Resume] Skipping guild ${player.guildId} because voice data is incomplete.`,
                 );
@@ -392,10 +393,10 @@ export async function resumeByLibrary(this: NodeStructure, players: PlayerStruct
                     paused: player.paused,
                 });
         } catch (error) {
-            this.nodeManager.manager.emit(EventNames.NodeError, this, error);
+            node.nodeManager.manager.emit(EventNames.NodeError, node, error);
         }
 
-        this.nodeManager.manager.debug(
+        node.nodeManager.manager.debug(
             DebugLevels.Node,
             `[Player] -> [Resume] Resumed player for guild ${player.guildId} using the library.`,
         );

--- a/src/util/events/websocket.ts
+++ b/src/util/events/websocket.ts
@@ -10,7 +10,6 @@ import {
     lyricsLine,
     lyricsNotFound,
     playerUpdate,
-    resumeByLibrary,
     socketClosed,
     trackEnd,
     trackError,
@@ -212,7 +211,8 @@ export async function onMessage(this: NodeStructure, message: Buffer | string): 
                     const players: PlayerStructure[] = this.nodeManager.manager.players.filter((p): boolean => p.node.id === this.id);
                     const isLibrary: boolean = sessionOptions.byLibrary;
 
-                    if (!payload.resumed && isLibrary && players.length) await resumeByLibrary.call(this, players);
+                    // `resumeFn` defaults to the built-in `resumeByLibrary`; a custom one replaces it.
+                    if (!payload.resumed && isLibrary && players.length) await sessionOptions.resumeFn(this, players);
 
                     this.info = await this.rest.request<NodeInfo>({ endpoint: RestRoutes.NodeInfo });
 

--- a/src/util/events/websocket.ts
+++ b/src/util/events/websocket.ts
@@ -47,7 +47,7 @@ export function onOpen(this: NodeStructure, res: IncomingMessage): void {
  * @param {NodeStructure} this The node that emitted the event.
  * @param {number} code The close code of the connection.
  * @param {string} reason The close reason message.
- * @returns {void}
+ * @returns {Promise<void>}
  */
 export async function onClose(this: NodeStructure, code: number, reason: string): Promise<void> {
     clearHeartbeatTimer.call(this);

--- a/src/util/functions/utils.ts
+++ b/src/util/functions/utils.ts
@@ -191,7 +191,7 @@ export function mergeDefault<T extends Record<string, any>>(def: T, given: T): D
  *
  * Get the default requester.
  * @param {TrackRequester} requester The requester to default.
- * @returns {TrackRequester} The default requester.
+ * @returns {T} The requester cast to the caller's type, or an empty object when it is absent or empty.
  */
 export function requesterFn<T>(requester: TrackRequester): T {
     if (!requester || typeof requester !== "object" || !Object.keys(requester).length) return {} as T;

--- a/src/util/functions/validations.ts
+++ b/src/util/functions/validations.ts
@@ -129,7 +129,7 @@ function validateManagerOptions(options: HoshimiOptions): void {
                 typeof options.nodeOptions.sessionOptions.byLibrary !== "undefined" &&
                 typeof options.nodeOptions.sessionOptions.byLibrary !== "boolean"
             )
-                throw new OptionError("The manager option 'options.nodeOptions.resumeByLibrary' must be a boolean.");
+                throw new OptionError("The manager option 'options.nodeOptions.sessionOptions.byLibrary' must be a boolean.");
         }
 
         if (isPlainObject(options.nodeOptions.moveOptions)) {

--- a/src/util/functions/validations.ts
+++ b/src/util/functions/validations.ts
@@ -121,7 +121,7 @@ function validateManagerOptions(options: HoshimiOptions): void {
                 typeof options.nodeOptions.sessionOptions.resumable !== "undefined" &&
                 typeof options.nodeOptions.sessionOptions.resumable !== "boolean"
             )
-                throw new OptionError("The manager option 'options.nodeOptions.resumable' must be a boolean.");
+                throw new OptionError("The manager option 'options.nodeOptions.sessionOptions.resumable' must be a boolean.");
 
             assertNonNegativeInteger(options.nodeOptions.sessionOptions.timeout, "options.nodeOptions.sessionOptions.timeout");
 
@@ -130,6 +130,12 @@ function validateManagerOptions(options: HoshimiOptions): void {
                 typeof options.nodeOptions.sessionOptions.byLibrary !== "boolean"
             )
                 throw new OptionError("The manager option 'options.nodeOptions.sessionOptions.byLibrary' must be a boolean.");
+
+            if (
+                typeof options.nodeOptions.sessionOptions.resumeFn !== "undefined" &&
+                typeof options.nodeOptions.sessionOptions.resumeFn !== "function"
+            )
+                throw new OptionError("The manager option 'options.nodeOptions.sessionOptions.resumeFn' must be a function.");
         }
 
         if (isPlainObject(options.nodeOptions.moveOptions)) {

--- a/tests/node/resume-fn.test.ts
+++ b/tests/node/resume-fn.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { resumeByLibrary as exportedResume } from "../../src";
+import { OptionError } from "../../src/classes/Errors";
+import type { HoshimiOptions } from "../../src/types/Manager";
+import { resumeByLibrary } from "../../src/util/events/player";
+import { onMessage } from "../../src/util/events/websocket";
+import { Validations } from "../../src/util/functions/validations";
+import { createRealManager, createRealNode, createRealPlayer } from "../helpers";
+
+const ready = (sessionId: string, resumed = false): string => JSON.stringify({ op: "ready", sessionId, resumed });
+
+describe("sessionOptions.resumeFn", () => {
+    it("defaults to the built-in resumeByLibrary", () => {
+        const manager = createRealManager();
+
+        expect(manager.options.nodeOptions.sessionOptions.resumeFn).toBe(resumeByLibrary);
+        // And it is the same function the package exports.
+        expect(exportedResume).toBe(resumeByLibrary);
+    });
+
+    it("keeps a custom handler over the default", () => {
+        const custom = vi.fn();
+        const manager = createRealManager({ nodeOptions: { sessionOptions: { resumeFn: custom } } } as never);
+
+        expect(manager.options.nodeOptions.sessionOptions.resumeFn).toBe(custom);
+    });
+
+    it("runs the handler on a fresh ready when byLibrary is on", async () => {
+        const custom = vi.fn().mockResolvedValue(undefined);
+        const manager = createRealManager({ nodeOptions: { sessionOptions: { byLibrary: true, resumeFn: custom } } } as never);
+        const node = createRealNode(manager);
+        const player = createRealPlayer(manager);
+
+        await onMessage.call(node, ready("session-1"));
+
+        expect(custom).toHaveBeenCalledTimes(1);
+        expect(custom).toHaveBeenCalledWith(node, [player]);
+    });
+
+    it("does not run when byLibrary is off", async () => {
+        const custom = vi.fn().mockResolvedValue(undefined);
+        const manager = createRealManager({ nodeOptions: { sessionOptions: { byLibrary: false, resumeFn: custom } } } as never);
+        const node = createRealNode(manager);
+        createRealPlayer(manager);
+
+        await onMessage.call(node, ready("session-1"));
+
+        expect(custom).not.toHaveBeenCalled();
+    });
+
+    it("does not run on a resumed session", async () => {
+        const custom = vi.fn().mockResolvedValue(undefined);
+        const manager = createRealManager({ nodeOptions: { sessionOptions: { byLibrary: true, resumeFn: custom } } } as never);
+        const node = createRealNode(manager);
+        vi.spyOn(node.rest, "getPlayers").mockResolvedValue([]);
+        createRealPlayer(manager);
+
+        await onMessage.call(node, ready("session-1", true));
+
+        expect(custom).not.toHaveBeenCalled();
+    });
+
+    it("rejects a resumeFn that is not a function", () => {
+        const base: HoshimiOptions = {
+            sendPayload: () => {},
+            nodes: [],
+            nodeOptions: { sessionOptions: { resumeFn: "nope" as never } },
+        } as never;
+
+        expect(() => Validations.validateManagerOptions(base)).toThrow(OptionError);
+    });
+});


### PR DESCRIPTION
Publishes `0.5.5`. The merge triggers the Publish workflow, which publishes to npm and creates the release entry.

Released as patch so it reaches existing `^0.5.x` installs; it carries one additive feature.

## Feature

`nodeOptions.sessionOptions` gained `resumeFn(node, players)`, a hook to customize how the library resumes a node's players — same shape as `autoplayFn`/`requesterFn`. It defaults to the built-in `resumeByLibrary`, which is now exported (and takes the node explicitly) so a custom handler can reuse or wrap it. Only runs while `byLibrary` is enabled.

```ts
new Hoshimi({
  nodeOptions: {
    sessionOptions: {
      byLibrary: true,
      resumeFn(node, players) { /* your resume logic */ },
    },
  },
});
```

## Housekeeping

- Fixed JSDoc that had drifted from the code across classes, types and util — wrong return/param types, copy-paste descriptions, and examples calling renamed or removed APIs. Also two stale validation error messages naming old option paths.
- `.editorconfig` mirroring the Biome formatter.
- Dev dependency bump (biome 2.5.9) and the pnpm package manager to 11.22.0.

## Verification

257 tests, `tsc` and Biome clean. The resume feature has six new tests, including one that drives a real ready frame through the socket handler and confirms a custom `resumeFn` is called with `(node, players)`; verified to fail against the previous wiring.