### PR TITLE
fix(queue): stop previous tracks re-entering history

### DIFF
--- a/src/classes/Track.ts
+++ b/src/classes/Track.ts
@@ -59,6 +59,15 @@ export class Track implements LavalinkTrack {
     public requester: TrackRequester;
 
     /**
+     * Whether this track was pulled from the history via {@link Queue.previous} to be replayed.
+     * When `true`, the track-end handler will not push it back into history, preventing a
+     * previous track from re-entering the history it was just taken from.
+     * @type {boolean}
+     * @default false
+     */
+    public isPrevious: boolean = false;
+
+    /**
      * The constructor for the track.
      * @param {LavalinkTrack | null} track The track to construct the track from.
      * @param {TrackRequester} requester The requester of the track.
@@ -85,6 +94,8 @@ export class Track implements LavalinkTrack {
         this.requester = requester ?? {};
         this.pluginInfo = track.pluginInfo;
         this.userData = track.userData ?? {};
+        // Preserved when restoring from stored JSON; a fresh Lavalink track has no such field.
+        this.isPrevious = "isPrevious" in track && !!track.isPrevious;
     }
 
     /**
@@ -116,6 +127,7 @@ export class Track implements LavalinkTrack {
             info: this.info,
             pluginInfo: this.pluginInfo,
             userData: this.userData,
+            isPrevious: this.isPrevious,
         };
     }
 }

--- a/src/classes/queue/Queue.ts
+++ b/src/classes/queue/Queue.ts
@@ -157,7 +157,12 @@ export class Queue {
     public async previous(remove: boolean = false): Promise<TrackStructure | null> {
         if (remove) {
             const track: TrackStructure | null = this.history.shift() ?? null;
-            if (track) await this.utils.save();
+            if (track) {
+                // Flag it so replaying it won't push it straight back into the history it just
+                // left when it ends naturally.
+                track.isPrevious = true;
+                await this.utils.save();
+            }
 
             return track;
         }

--- a/src/types/Queue.ts
+++ b/src/types/Queue.ts
@@ -58,6 +58,12 @@ export interface SyncOptions {
  */
 export interface TrackJSON extends LavalinkTrack {
     requester: TrackRequester;
+    /**
+     * Whether the track was taken from history to be replayed. Persisted so the flag survives
+     * a queue save/restore.
+     * @type {boolean}
+     */
+    isPrevious?: boolean;
 }
 
 /**

--- a/src/util/events/player.ts
+++ b/src/util/events/player.ts
@@ -29,6 +29,8 @@ import { isPlayerGone, stringify } from "../functions/utils";
 async function onEnd(this: PlayerStructure, updateCurrent: boolean = true): Promise<void> {
     if (
         this.queue.current &&
+        // A track pulled from history via previous() must not be pushed back into it.
+        !this.queue.current.isPrevious &&
         !this.queue.history.find(
             (x): boolean => x.info.identifier === this.queue.current!.info.identifier && x.info.title === this.queue.current!.info.title,
         )
@@ -154,8 +156,12 @@ export async function trackEnd(this: PlayerStructure, payload: TrackEndEvent): P
     const current: TrackStructure | null = this.queue.current;
 
     if (payload.reason === TrackEndReason.Replaced) {
+        // A replace is a user-forced play() over active playback. Mirror lavalink-client: emit the
+        // end event and return WITHOUT touching history. `queue.current` has already been advanced
+        // to the replacement by play(), so it is not the ended track; and the outgoing track should
+        // not be pushed to history from a replace at all (natural ends are what populate history).
         this.manager.emit(EventNames.TrackEnd, this, current, payload);
-        return onEnd.call(this, false);
+        return;
     }
 
     const isStopPlaying = await this.data.get("internal_stopPlaying");

--- a/tests/player/previous-history.test.ts
+++ b/tests/player/previous-history.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { PlayerEventType, type TrackEndEvent, TrackEndReason } from "../../src/types/Player";
+import { Structures } from "../../src/types/Structures";
+import { trackEnd } from "../../src/util/events/player";
+import { createMockTrackData, createRealManager, createRealNode, createRealPlayer } from "../helpers";
+
+describe("previous(true) history navigation", () => {
+    it("marks the pulled track as isPrevious", async () => {
+        const manager = createRealManager();
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+
+        const A = Structures.Track(createMockTrackData({ info: { identifier: "A", title: "Track A" } }) as never, {});
+        player.queue.history = [A];
+
+        const prev = await player.queue.previous(true);
+        expect(prev).toBe(A);
+        expect(prev!.isPrevious).toBe(true);
+        expect(player.queue.history).toEqual([]);
+    });
+
+    it("a REPLACED end does not touch history", async () => {
+        const manager = createRealManager();
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+
+        const A = Structures.Track(createMockTrackData({ info: { identifier: "A", title: "Track A" } }) as never, {});
+        const B = Structures.Track(createMockTrackData({ info: { identifier: "B", title: "Track B" } }) as never, {});
+
+        player.queue.current = B;
+        player.queue.history = [A];
+
+        await player.queue.previous(true); // removes A, history []
+        vi.spyOn(player, "updatePlayer").mockResolvedValue(null);
+        await player.play({ track: A }); // current -> A, replace B
+
+        await trackEnd.call(player, {
+            type: PlayerEventType.TrackEnd,
+            guildId: player.guildId,
+            reason: TrackEndReason.Replaced,
+            track: B,
+        } as unknown as TrackEndEvent);
+
+        expect(player.queue.history).toEqual([]); // neither A nor B re-added on replace
+    });
+
+    it("a previous-sourced track ending naturally is not re-added to history", async () => {
+        const manager = createRealManager();
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+
+        const A = Structures.Track(createMockTrackData({ info: { identifier: "A", title: "Track A" } }) as never, {});
+        player.queue.history = [A];
+
+        const prev = await player.queue.previous(true); // A.isPrevious = true
+        player.queue.current = prev; // now playing A (from history)
+
+        // A finishes naturally with an empty queue -> queueEnd path runs onEnd(false)
+        await trackEnd.call(player, {
+            type: PlayerEventType.TrackEnd,
+            guildId: player.guildId,
+            reason: TrackEndReason.Finished,
+            track: A,
+        } as unknown as TrackEndEvent);
+
+        const ids = player.queue.history.map((t) => t.info.identifier);
+        expect(ids).not.toContain("A"); // guard prevented the ping-pong
+    });
+
+    it("a normal track ending naturally IS added to history", async () => {
+        const manager = createRealManager();
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+
+        const A = Structures.Track(createMockTrackData({ info: { identifier: "A", title: "Track A" } }) as never, {});
+        const B = Structures.Track(createMockTrackData({ info: { identifier: "B", title: "Track B" } }) as never, {});
+        player.queue.current = A; // fresh track, isPrevious = false
+        player.queue.tracks = [B]; // a next track exists, so the queue does not end here
+        vi.spyOn(player, "updatePlayer").mockResolvedValue(null);
+
+        await trackEnd.call(player, {
+            type: PlayerEventType.TrackEnd,
+            guildId: player.guildId,
+            reason: TrackEndReason.Finished,
+            track: A,
+        } as unknown as TrackEndEvent);
+
+        expect(player.queue.history.map((t) => t.info.identifier)).toContain("A");
+    });
+
+    it("isPrevious survives toJSON -> rebuild", () => {
+        const A = Structures.Track(createMockTrackData({ info: { identifier: "A", title: "Track A" } }) as never, {});
+        A.isPrevious = true;
+
+        const json = A.toJSON();
+        expect(json.isPrevious).toBe(true);
+
+        const rebuilt = Structures.Track(json as never, json.requester);
+        expect(rebuilt.isPrevious).toBe(true);
+    });
+});


### PR DESCRIPTION
Stops queue history navigation from re-adding a track pulled with `previous(true)`.

A replaced end previously ran normal queue progression after playback had already moved `queue.current`, adding the wrong track to history. Replaced ends now emit the event and return, while tracks returned from history carry persisted `isPrevious` state so natural completion does not reinsert them.
