### PR TITLE
refactor: consolidate the track-end / queue-advance flow

### DIFF
--- a/src/classes/Track.ts
+++ b/src/classes/Track.ts
@@ -59,15 +59,6 @@ export class Track implements LavalinkTrack {
     public requester: TrackRequester;
 
     /**
-     * Whether this track was pulled from the history via {@link Queue.previous} to be replayed.
-     * When `true`, the track-end handler will not push it back into history, preventing a
-     * previous track from re-entering the history it was just taken from.
-     * @type {boolean}
-     * @default false
-     */
-    public isPrevious: boolean = false;
-
-    /**
      * The constructor for the track.
      * @param {LavalinkTrack | null} track The track to construct the track from.
      * @param {TrackRequester} requester The requester of the track.
@@ -94,8 +85,6 @@ export class Track implements LavalinkTrack {
         this.requester = requester ?? {};
         this.pluginInfo = track.pluginInfo;
         this.userData = track.userData ?? {};
-        // Preserved when restoring from stored JSON; a fresh Lavalink track has no such field.
-        this.isPrevious = "isPrevious" in track && !!track.isPrevious;
     }
 
     /**
@@ -127,7 +116,6 @@ export class Track implements LavalinkTrack {
             info: this.info,
             pluginInfo: this.pluginInfo,
             userData: this.userData,
-            isPrevious: this.isPrevious,
         };
     }
 }

--- a/src/classes/queue/Queue.ts
+++ b/src/classes/queue/Queue.ts
@@ -157,12 +157,7 @@ export class Queue {
     public async previous(remove: boolean = false): Promise<TrackStructure | null> {
         if (remove) {
             const track: TrackStructure | null = this.history.shift() ?? null;
-            if (track) {
-                // Flag it so replaying it won't push it straight back into the history it just
-                // left when it ends naturally.
-                track.isPrevious = true;
-                await this.utils.save();
-            }
+            if (track) await this.utils.save();
 
             return track;
         }

--- a/src/types/Queue.ts
+++ b/src/types/Queue.ts
@@ -58,12 +58,6 @@ export interface SyncOptions {
  */
 export interface TrackJSON extends LavalinkTrack {
     requester: TrackRequester;
-    /**
-     * Whether the track was taken from history to be replayed. Persisted so the flag survives
-     * a queue save/restore.
-     * @type {boolean}
-     */
-    isPrevious?: boolean;
 }
 
 /**

--- a/src/util/events/player.ts
+++ b/src/util/events/player.ts
@@ -83,8 +83,11 @@ async function queueEnd(
 
         this.manager.debug(DebugLevels.Player, "[Queue] -> [Autoplay] Autoplay function executed.");
 
-        if (this.queue.size > 0) await onEnd.call(this);
-        if (this.queue.current) {
+        // Autoplay seeds the queue; play() shifts the first track into current and plays it. Running
+        // onEnd here first would shift one track in, and play()'s own shift would then skip past it —
+        // and with a single seeded track the second shift hits an empty queue and crashes in build().
+        // So go straight to play(), which advances exactly once.
+        if (this.queue.size > 0) {
             if (payload.type === PlayerEventType.TrackEnd) this.manager.emit(EventNames.TrackEnd, this, track, payload);
 
             this.manager.debug(DebugLevels.Player, "[Queue] -> [Autoplay] Track(s) queued from autoplay function.");

--- a/src/util/events/player.ts
+++ b/src/util/events/player.ts
@@ -28,8 +28,6 @@ import { isPlayerGone, stringify } from "../functions/utils";
 async function onEnd(this: PlayerStructure): Promise<void> {
     if (
         this.queue.current &&
-        // A track pulled from history via previous() must not be pushed back into it.
-        !this.queue.current.isPrevious &&
         !this.queue.history.find(
             (x): boolean => x.info.identifier === this.queue.current!.info.identifier && x.info.title === this.queue.current!.info.title,
         )

--- a/src/util/events/player.ts
+++ b/src/util/events/player.ts
@@ -23,10 +23,9 @@ import { isPlayerGone, stringify } from "../functions/utils";
  *
  * Emitted when a queue track ends.
  * @param {PlayerStructure} this The player that emitted the event.
- * @param {boolean} [updateCurrent=true] Whether to update the current track or not.
  * @returns {Promise<void>} Yeah, this is something weird but it works.
  */
-async function onEnd(this: PlayerStructure, updateCurrent: boolean = true): Promise<void> {
+async function onEnd(this: PlayerStructure): Promise<void> {
     if (
         this.queue.current &&
         // A track pulled from history via previous() must not be pushed back into it.
@@ -50,7 +49,8 @@ async function onEnd(this: PlayerStructure, updateCurrent: boolean = true): Prom
     if (this.loop === LoopMode.Track && this.queue.current) await this.queue.unshift(this.queue.current);
     if (this.loop === LoopMode.Queue && this.queue.current) await this.queue.add(this.queue.current);
 
-    if (!this.queue.current && updateCurrent) this.queue.current = await this.queue.utils.build(await this.queue.shift());
+    // No shift here: play() is the sole place the queue advances (it shifts the next track into
+    // current). onEnd only records history and applies the loop mode.
 
     await this.queue.utils.save();
 
@@ -104,7 +104,7 @@ async function queueEnd(
 
     if (payload.type === PlayerEventType.TrackEnd && payload.reason !== TrackEndReason.Stopped) await this.queue.utils.save();
 
-    await onEnd.call(this, false);
+    await onEnd.call(this);
 
     this.manager.emit(EventNames.QueueEnd, this, this.queue);
     this.manager.debug(DebugLevels.Player, "[Player] -> [Queue] The queue has ended.");

--- a/tests/player/autoplay-advance.test.ts
+++ b/tests/player/autoplay-advance.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { PlayerEventType, TrackEndReason } from "../../src/types/Player";
+import type { PlayerStructure } from "../../src/types/Structures";
+import { Structures } from "../../src/types/Structures";
+import { trackEnd } from "../../src/util/events/player";
+import { createMockTrackData, createRealManager, createRealNode, createRealPlayer } from "../helpers";
+
+const track = (identifier: string) => Structures.Track(createMockTrackData({ info: { identifier } }), {});
+
+const endEvent = {
+    op: "event",
+    type: PlayerEventType.TrackEnd,
+    guildId: "guild-1",
+    track: createMockTrackData(),
+    reason: TrackEndReason.Finished,
+} as never;
+
+/**
+ * `queueEnd` nulls `current` before running the autoplay hook, so it must let `play()` do the single
+ * shift-and-play. It used to also call `onEnd` first, which shifted one track in on its own — `play()`
+ * then shifted again, skipping that track (two seeded) or hitting an empty queue and crashing in
+ * `build()` (one seeded).
+ */
+describe("autoplay does not double-advance", () => {
+    it("plays a single seeded track instead of crashing", async () => {
+        const autoplayFn = vi.fn(async (player: PlayerStructure) => {
+            await player.queue.add(track("auto-1"));
+        });
+        const manager = createRealManager({ queueOptions: { autoplayFn } } as never);
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+        player.queue.current = track("ended");
+
+        await expect(trackEnd.call(player, endEvent)).resolves.toBeUndefined();
+
+        expect(player.queue.current?.info.identifier).toBe("auto-1");
+        expect(player.queue.tracks).toHaveLength(0);
+    });
+
+    it("plays the first of several seeded tracks and keeps the rest queued", async () => {
+        const autoplayFn = vi.fn(async (player: PlayerStructure) => {
+            await player.queue.add(track("auto-1"));
+            await player.queue.add(track("auto-2"));
+        });
+        const manager = createRealManager({ queueOptions: { autoplayFn } } as never);
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+        player.queue.current = track("ended");
+
+        await trackEnd.call(player, endEvent);
+
+        // The first seeded track plays; the second waits its turn instead of being skipped.
+        expect(player.queue.current?.info.identifier).toBe("auto-1");
+        expect(player.queue.tracks.map((t) => t.info.identifier)).toEqual(["auto-2"]);
+    });
+
+    it("still ends the queue when autoplay seeds nothing", async () => {
+        const autoplayFn = vi.fn().mockResolvedValue(undefined);
+        const manager = createRealManager({ queueOptions: { autoplayFn } } as never);
+        createRealNode(manager);
+        const player = createRealPlayer(manager);
+        player.queue.current = track("ended");
+
+        const queueEnd = vi.fn();
+        manager.on("queueEnd", queueEnd);
+
+        await trackEnd.call(player, endEvent);
+
+        expect(queueEnd).toHaveBeenCalledTimes(1);
+        expect(player.queue.current).toBeNull();
+    });
+});

--- a/tests/player/previous-history.test.ts
+++ b/tests/player/previous-history.test.ts
@@ -5,7 +5,7 @@ import { trackEnd } from "../../src/util/events/player";
 import { createMockTrackData, createRealManager, createRealNode, createRealPlayer } from "../helpers";
 
 describe("previous(true) history navigation", () => {
-    it("marks the pulled track as isPrevious", async () => {
+    it("removes the pulled track from history and returns it", async () => {
         const manager = createRealManager();
         createRealNode(manager);
         const player = createRealPlayer(manager);
@@ -15,7 +15,6 @@ describe("previous(true) history navigation", () => {
 
         const prev = await player.queue.previous(true);
         expect(prev).toBe(A);
-        expect(prev!.isPrevious).toBe(true);
         expect(player.queue.history).toEqual([]);
     });
 
@@ -41,40 +40,17 @@ describe("previous(true) history navigation", () => {
             track: B,
         } as unknown as TrackEndEvent);
 
-        expect(player.queue.history).toEqual([]); // neither A nor B re-added on replace
+        expect(player.queue.history).toEqual([]); // the replaced (forced) end never populates history
     });
 
-    it("a previous-sourced track ending naturally is not re-added to history", async () => {
-        const manager = createRealManager();
-        createRealNode(manager);
-        const player = createRealPlayer(manager);
-
-        const A = Structures.Track(createMockTrackData({ info: { identifier: "A", title: "Track A" } }) as never, {});
-        player.queue.history = [A];
-
-        const prev = await player.queue.previous(true); // A.isPrevious = true
-        player.queue.current = prev; // now playing A (from history)
-
-        // A finishes naturally with an empty queue -> queueEnd path runs onEnd(false)
-        await trackEnd.call(player, {
-            type: PlayerEventType.TrackEnd,
-            guildId: player.guildId,
-            reason: TrackEndReason.Finished,
-            track: A,
-        } as unknown as TrackEndEvent);
-
-        const ids = player.queue.history.map((t) => t.info.identifier);
-        expect(ids).not.toContain("A"); // guard prevented the ping-pong
-    });
-
-    it("a normal track ending naturally IS added to history", async () => {
+    it("a track ending naturally IS added to history", async () => {
         const manager = createRealManager();
         createRealNode(manager);
         const player = createRealPlayer(manager);
 
         const A = Structures.Track(createMockTrackData({ info: { identifier: "A", title: "Track A" } }) as never, {});
         const B = Structures.Track(createMockTrackData({ info: { identifier: "B", title: "Track B" } }) as never, {});
-        player.queue.current = A; // fresh track, isPrevious = false
+        player.queue.current = A;
         player.queue.tracks = [B]; // a next track exists, so the queue does not end here
         vi.spyOn(player, "updatePlayer").mockResolvedValue(null);
 
@@ -86,16 +62,5 @@ describe("previous(true) history navigation", () => {
         } as unknown as TrackEndEvent);
 
         expect(player.queue.history.map((t) => t.info.identifier)).toContain("A");
-    });
-
-    it("isPrevious survives toJSON -> rebuild", () => {
-        const A = Structures.Track(createMockTrackData({ info: { identifier: "A", title: "Track A" } }) as never, {});
-        A.isPrevious = true;
-
-        const json = A.toJSON();
-        expect(json.isPrevious).toBe(true);
-
-        const rebuilt = Structures.Track(json as never, json.requester);
-        expect(rebuilt.isPrevious).toBe(true);
     });
 });


### PR DESCRIPTION
Draft — still being tested against the bot via the pkg.pr.new preview (`npm i https://pkg.pr.new/hoshimi@3ffdb5f`).

Three related changes to the track-end flow in `src/util/events/player.ts`, each its own commit.

## 1. fix: autoplay no longer double-advances (`0f30c76`)

`queueEnd` nulls `current` before running the autoplay hook, so `onEnd` shifted one seeded track into `current` and `play()`'s own shift then skipped past it. A single seeded track even crashed in `build()` (second shift on an empty queue → `ResolveError`); two or more silently dropped the first. The autoplay branch now goes straight to `play()`, which advances exactly once.

## 2. refactor: play() is the sole queue-advance point (`ddf9570`)

With #1 in place, `onEnd`'s conditional shift (`if (!current && updateCurrent) …`) was dead code — every caller passes a non-null `current` or `updateCurrent: false`. Removed it and the now-purposeless `updateCurrent` param. `onEnd` is now purely history + loop + save; `play()` is the only place the queue advances, so the split-advance class of bug can't recur.

## 3. refactor: drop the isPrevious flag (`3ffdb5f`)

The `previous()` loop `isPrevious` guarded came from a forced `play({ track })` re-adding the track on a `Replaced` end — which the `Replaced` early-return (kept) already prevents. The flag only still affected **natural** ends: a replayed track no longer re-entered history.

**Behavior change:** without the flag, a track pulled via `previous()` that then plays to a natural end **does** re-enter history — matching lavalink-client, which re-adds on natural end. Removed the `Track.isPrevious` field, its JSON persistence, the `previous()` marking, and the `onEnd` guard.

## Verification

263 tests, `tsc` and Biome clean. New/updated tests: `autoplay-advance.test.ts` (crash + skip cases, each confirmed to fail against the pre-fix code) and `previous-history.test.ts` (rewritten: `previous(true)` removal, the `Replaced` no-history early-return, and normal natural-end history add).

## Not for release yet

Testing in the bot first (autoplay skip/crash, and the previous re-add behavior). Marking draft until that's confirmed.